### PR TITLE
Fix bugs across codegen, validation, shapes, and UI; add clipboard + keyboard shortcuts

### DIFF
--- a/app/api/examples/[...filename]/route.ts
+++ b/app/api/examples/[...filename]/route.ts
@@ -8,12 +8,13 @@ export async function GET(
 ) {
   const filename = params.filename.join('/');
 
-  // Prevent path traversal
-  if (filename.includes('..')) {
+  // Prevent path traversal: resolve and verify the path stays inside the
+  // examples directory instead of relying on a substring blocklist
+  const baseDir = path.resolve(process.cwd(), 'lib', 'examples');
+  const filePath = path.resolve(baseDir, filename);
+  if (filePath !== baseDir && !filePath.startsWith(baseDir + path.sep)) {
     return new NextResponse('Invalid filename', { status: 400 });
   }
-
-  const filePath = path.join(process.cwd(), 'lib', 'examples', filename);
 
   try {
     const fileContents = await fs.readFile(filePath, 'utf8');

--- a/app/api/generate-model/route.ts
+++ b/app/api/generate-model/route.ts
@@ -6,7 +6,7 @@ export async function POST(request: NextRequest) {
   try {
     const body: GenerateModelRequest = await request.json()
 
-    if (!body.nodes || !body.edges) {
+    if (!Array.isArray(body.nodes) || !Array.isArray(body.edges)) {
       return NextResponse.json(
         {
           success: false,

--- a/app/api/validate-graph/route.ts
+++ b/app/api/validate-graph/route.ts
@@ -6,7 +6,7 @@ export async function POST(request: NextRequest) {
   try {
     const body: GenerateModelRequest = await request.json()
 
-    if (!body.nodes || !body.edges) {
+    if (!Array.isArray(body.nodes) || !Array.isArray(body.edges)) {
       return NextResponse.json(
         {
           valid: false,

--- a/app/api/visualize-model/route.ts
+++ b/app/api/visualize-model/route.ts
@@ -6,7 +6,7 @@ export async function POST(request: NextRequest) {
   try {
     const body: GenerateModelRequest = await request.json()
 
-    if (!body.nodes || !body.edges) {
+    if (!Array.isArray(body.nodes) || !Array.isArray(body.edges)) {
       return NextResponse.json(
         {
           success: false,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,7 @@
 
 import type React from "react"
 
-import { useState, useCallback, useEffect, useRef } from "react"
+import { useState, useCallback, useEffect, useMemo, useRef } from "react"
 import {
   ReactFlow,
   ReactFlowProvider,
@@ -76,12 +76,19 @@ import { analyzeModel, formatNumber, type ModelAnalysis } from "@/lib/model-anal
 import { useAutoSave, StorageUtils } from "@/lib/auto-save"
 import { useModelValidation } from "@/lib/model-validator"
 import { useUndoRedo } from "@/lib/undo-redo"
+import { useKeyboardShortcuts } from "@/lib/keyboard-shortcuts"
 import { Input } from "@/components/ui/input"
 import { EditableNumberInput } from "@/components/ui/EditableNumberInput"
 
 // Custom Node Components
 import { InputNode } from "@/components/nodes/InputNode"
 import { ConstantNode } from "@/components/nodes/ConstantNode"
+import { MaxPool1DNode } from "@/components/nodes/MaxPool1DNode"
+import { MaxPool3DNode } from "@/components/nodes/MaxPool3DNode"
+import { BatchNorm3DNode } from "@/components/nodes/BatchNorm3DNode"
+import { FractionalMaxPool2DNode } from "@/components/nodes/FractionalMaxPool2DNode"
+import { LPPool2DNode } from "@/components/nodes/LPPool2DNode"
+import { AdaptiveMaxPool1DNode } from "@/components/nodes/AdaptiveMaxPool1DNode"
 import { LinearNode } from "@/components/nodes/LinearNode"
 import { TimeDistributedLinearNode } from "@/components/nodes/TimeDistributedLinearNode"
 import { Conv2DNode } from "@/components/nodes/Conv2DNode"
@@ -236,11 +243,17 @@ const nodeTypes: NodeTypes = {
   hardsigmoidNode: HardsigmoidNode,
   dropoutNode: DropoutNode,
   flattenNode: FlattenNode,
+  maxpool1dNode: MaxPool1DNode,
   maxpool2dNode: MaxPool2DNode,
+  maxpool3dNode: MaxPool3DNode,
   avgpool2dNode: AvgPool2DNode,
   adaptiveavgpool2dNode: AdaptiveAvgPool2DNode,
+  adaptivemaxpool1dNode: AdaptiveMaxPool1DNode,
+  fractionalmaxpool2dNode: FractionalMaxPool2DNode,
+  lppool2dNode: LPPool2DNode,
   batchnorm1dNode: BatchNorm1DNode,
   batchnorm2dNode: BatchNorm2DNode,
+  batchnorm3dNode: BatchNorm3DNode,
   layernormNode: LayerNormNode,
   groupnormNode: GroupNormNode,
   instancenorm1dNode: InstanceNorm1DNode,
@@ -286,6 +299,7 @@ export default function NeuralNetworkDesigner() {
     undo,
     redo,
     takeSnapshot,
+    resetHistory,
     canUndo,
     canRedo,
   } = useUndoRedo(initialNodes, initialEdges)
@@ -349,6 +363,15 @@ export default function NeuralNetworkDesigner() {
 
   const isInputConnected = selectedNode ? edges.some((edge) => edge.target === selectedNode.id) : false
 
+  // Live total-parameter count shown in the header
+  const totalParameters = useMemo(() => {
+    try {
+      return analyzeModel(nodes, edges).totalParameters
+    } catch {
+      return 0
+    }
+  }, [nodes, edges])
+
   useEffect(() => {
     const handleAutoSaveRequest = () => {
       if (typeof window !== "undefined") {
@@ -368,8 +391,7 @@ export default function NeuralNetworkDesigner() {
     if (autoSave.hasSavedData()) {
       const loadedState = autoSave.load()
       if (loadedState) {
-        setNodes(loadedState.nodes)
-        setEdges(loadedState.edges)
+        resetHistory(loadedState.nodes, loadedState.edges)
         toast({
           title: "Session Restored",
           description: "Your previous session has been loaded.",
@@ -919,6 +941,7 @@ export default function NeuralNetworkDesigner() {
           takeSnapshot();
           setNodes(importedData.nodes);
           setEdges(importedData.edges);
+          setSelectedNode(null);
           const importedModelName = importedData.name || file.name.replace('.json', '');
           setCurrentModelName(importedModelName);
           toast({ title: "Model Imported", description: `Successfully imported "${importedModelName}"` });
@@ -954,6 +977,7 @@ export default function NeuralNetworkDesigner() {
         takeSnapshot()
         setNodes(loadedState.nodes)
         setEdges(loadedState.edges)
+        setSelectedNode(null)
         toast({ title: "Model Loaded", description: `Model has been loaded successfully.` })
         setShowLoadDialog(false)
 
@@ -982,11 +1006,12 @@ export default function NeuralNetworkDesigner() {
         body: JSON.stringify({ nodes, edges }),
       })
 
-      if (!response.ok) {
-        throw new Error("Failed to generate model")
+      const data = await response.json().catch(() => null)
+
+      if (!response.ok || !data?.success) {
+        throw new Error(data?.error || "Failed to generate model")
       }
 
-      const data = await response.json()
       setGeneratedCode(data.code)
 
       setShowCodeDialog(true)
@@ -997,7 +1022,7 @@ export default function NeuralNetworkDesigner() {
     } catch (error) {
       toast({
         title: "Generation Failed",
-        description: "Failed to generate model code",
+        description: error instanceof Error ? error.message : "Failed to generate model code",
         variant: "destructive",
       })
     } finally {
@@ -1070,6 +1095,119 @@ export default function NeuralNetworkDesigner() {
         unsecuredCopyToClipboard(generatedCode);
     }
 }, [generatedCode, toast]);
+
+  // --- Clipboard (copy/paste/cut) for canvas nodes ---
+  const clipboardRef = useRef<{ nodes: Node[]; edges: Edge[] } | null>(null)
+
+  const copySelectedNodes = useCallback(() => {
+    const selectedNodes = nodes.filter((n) => n.selected)
+    if (selectedNodes.length === 0) return false
+    const selectedIds = new Set(selectedNodes.map((n) => n.id))
+    const internalEdges = edges.filter((e) => selectedIds.has(e.source) && selectedIds.has(e.target))
+    clipboardRef.current = {
+      nodes: JSON.parse(JSON.stringify(selectedNodes)),
+      edges: JSON.parse(JSON.stringify(internalEdges)),
+    }
+    toast({ title: "Copied", description: `Copied ${selectedNodes.length} node(s)` })
+    return true
+  }, [nodes, edges, toast])
+
+  const pasteNodes = useCallback(() => {
+    const clipboard = clipboardRef.current
+    if (!clipboard || clipboard.nodes.length === 0) return
+    takeSnapshot()
+
+    const idMap = new Map<string, string>()
+    const suffix = Date.now().toString(36)
+    const pastedNodes = clipboard.nodes.map((node, i) => {
+      const newId = `${node.type}_${suffix}_${i}`
+      idMap.set(node.id, newId)
+      return {
+        ...node,
+        id: newId,
+        selected: true,
+        position: { x: node.position.x + 40, y: node.position.y + 40 },
+        data: JSON.parse(JSON.stringify(node.data)),
+      }
+    })
+    const pastedEdges = clipboard.edges.map((edge, i) => ({
+      ...edge,
+      id: `edge_${suffix}_${i}`,
+      source: idMap.get(edge.source)!,
+      target: idMap.get(edge.target)!,
+      selected: false,
+    }))
+
+    setNodes((nds) => [...nds.map((n) => ({ ...n, selected: false })), ...pastedNodes])
+    setEdges((eds) => [...eds, ...pastedEdges])
+    toast({ title: "Pasted", description: `Pasted ${pastedNodes.length} node(s)` })
+  }, [setNodes, setEdges, takeSnapshot, toast])
+
+  const duplicateNode = useCallback(
+    (nodeToCopy: Node) => {
+      takeSnapshot()
+      const newId = `${nodeToCopy.type}_${Date.now().toString(36)}`
+      const newNode: Node = {
+        ...nodeToCopy,
+        id: newId,
+        selected: false,
+        position: { x: nodeToCopy.position.x + 40, y: nodeToCopy.position.y + 40 },
+        data: JSON.parse(JSON.stringify(nodeToCopy.data)),
+      }
+      setNodes((nds) => [...nds, newNode])
+      toast({ title: "Node Duplicated", description: `Created ${newId}` })
+    },
+    [setNodes, takeSnapshot, toast],
+  )
+
+  const cutSelectedNodes = useCallback(() => {
+    if (!copySelectedNodes()) return
+    takeSnapshot()
+    const selectedIds = new Set(nodes.filter((n) => n.selected).map((n) => n.id))
+    setNodes((nds) => nds.filter((n) => !selectedIds.has(n.id)))
+    setEdges((eds) => eds.filter((e) => !selectedIds.has(e.source) && !selectedIds.has(e.target)))
+    if (selectedNode && selectedIds.has(selectedNode.id)) {
+      setSelectedNode(null)
+    }
+  }, [copySelectedNodes, nodes, selectedNode, setNodes, setEdges, takeSnapshot])
+
+  // Activate global keyboard shortcuts (they dispatch the CustomEvents handled below)
+  useKeyboardShortcuts()
+
+  useEffect(() => {
+    const handlers: Record<string, () => void> = {
+      "save-model": () => setShowSaveDialog(true),
+      "open-model": handleOpenLoadDialog,
+      "new-model": resetCanvas,
+      "reset-canvas": resetCanvas,
+      undo,
+      redo,
+      "generate-code": generateModel,
+      "toggle-help": () => setShowHelpDialog((prev) => !prev),
+      "fit-view": () => reactFlowInstanceRef.current?.fitView({ padding: 0.1, duration: 200 }),
+      "select-all": () => setNodes((nds) => nds.map((n) => ({ ...n, selected: true }))),
+      "deselect-all": () => setNodes((nds) => nds.map((n) => ({ ...n, selected: false }))),
+      "copy-selected": copySelectedNodes,
+      "paste-nodes": pasteNodes,
+      "cut-selected": cutSelectedNodes,
+    }
+
+    const entries = Object.entries(handlers)
+    entries.forEach(([event, handler]) => window.addEventListener(event, handler))
+    return () => {
+      entries.forEach(([event, handler]) => window.removeEventListener(event, handler))
+    }
+  }, [
+    handleOpenLoadDialog,
+    resetCanvas,
+    undo,
+    redo,
+    generateModel,
+    setNodes,
+    copySelectedNodes,
+    pasteNodes,
+    cutSelectedNodes,
+  ])
 
   const parsePyTorchCode = useCallback(
     (code: string) => {
@@ -1201,7 +1339,8 @@ export default function NeuralNetworkDesigner() {
           layerMap.set(layerName, nodeId)
 
           const nodeType = nodeTypeMap[layerType]
-          if (!nodeType) {
+          // Only create nodes for types the canvas can actually render
+          if (!nodeType || !nodeTypes[nodeType]) {
             unsupportedModules.push(layerType)
             warnings.push(`Unsupported layer type: ${layerType}. This layer will be skipped in visualization.`)
             return
@@ -1398,6 +1537,7 @@ export default function NeuralNetworkDesigner() {
     takeSnapshot()
     setNodes(result.nodes)
     setEdges(result.edges)
+    setSelectedNode(null)
     setParseErrors([])
     setParseWarnings(result.warnings)
     setUnsupportedModules(result.unsupportedModules)
@@ -1423,8 +1563,18 @@ export default function NeuralNetworkDesigner() {
   const keyboardShortcuts = [
     { key: "Ctrl + S", description: "Save model" },
     { key: "Ctrl + O", description: "Open model" },
+    { key: "Ctrl + N", description: "New model (reset canvas)" },
     { key: "Ctrl + G", description: "Generate PyTorch code" },
     { key: "Ctrl + R", description: "Reset canvas" },
+    { key: "Ctrl + Z", description: "Undo" },
+    { key: "Ctrl + Y / Ctrl + Shift + Z", description: "Redo" },
+    { key: "Ctrl + A", description: "Select all nodes" },
+    { key: "Ctrl + D", description: "Deselect all nodes" },
+    { key: "Ctrl + C", description: "Copy selected nodes" },
+    { key: "Ctrl + X", description: "Cut selected nodes" },
+    { key: "Ctrl + V", description: "Paste nodes" },
+    { key: "Ctrl + F", description: "Fit view to canvas" },
+    { key: "H", description: "Toggle help dialog" },
     { key: "Delete / Backspace", description: "Delete selected nodes" },
   ]
 
@@ -1505,6 +1655,11 @@ export default function NeuralNetworkDesigner() {
             <h1 className="text-2xl font-bold text-foreground">{currentModelName || "Neural Network Designer"}</h1>
             <p className="text-sm text-muted-foreground">Build PyTorch models visually</p>
           </div>
+          {totalParameters > 0 && (
+            <Badge variant="secondary" className="ml-2" title={`${totalParameters.toLocaleString()} trainable parameters`}>
+              {formatNumber(totalParameters)} params
+            </Badge>
+          )}
         </div>
         <div className="flex items-center gap-2">
           <Button variant="outline" size="sm" onClick={() => setShowHelpDialog(true)}>
@@ -1551,6 +1706,10 @@ export default function NeuralNetworkDesigner() {
           <Button variant="outline" size="sm" onClick={analyzeCurrentModel} disabled={nodes.length === 0}>
             <BarChart3 className="h-4 w-4 mr-2" />
             Model Analysis
+          </Button>
+          <Button variant="outline" size="sm" onClick={() => setShowCodeInputDialog(true)}>
+            <FileUp className="h-4 w-4 mr-2" />
+            Import Code
           </Button>
           <Button onClick={generateModel} disabled={isGenerating} className="flex items-center">
             {isGenerating ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Code className="h-4 w-4 mr-2" />}
@@ -2106,7 +2265,7 @@ export default function NeuralNetworkDesigner() {
                     </div>
                   </Card>
                   <Card
-                    className="p-3 cursor-pointer hover:bg-sidebar-accent/50 transition-.colors border-sidebar-border"
+                    className="p-3 cursor-pointer hover:bg-sidebar-accent/50 transition-colors border-sidebar-border"
                     onClick={() => addNode("transformerdecoderlayerNode", { d_model: 512, nhead: 8 })}
                   >
                     <div className="flex items-center gap-2">
@@ -2197,6 +2356,15 @@ export default function NeuralNetworkDesigner() {
                     />
                   </div>
                 </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="w-full"
+                  onClick={() => duplicateNode(selectedNode)}
+                >
+                  <Copy className="h-3.5 w-3.5 mr-1.5" />
+                  Duplicate Node
+                </Button>
                 <Separator />
                 <div className="space-y-3">
                   {selectedNode.type === "inputNode" && (
@@ -2260,15 +2428,24 @@ export default function NeuralNetworkDesigner() {
                       <div>
                         <label className="text-sm font-medium text-sidebar-foreground/70">Shape</label>
                         <Input
-                          value={JSON.stringify(selectedNode.data.shape || [])}
-                          onChange={(e) => {
+                          key={selectedNode.id}
+                          defaultValue={JSON.stringify(selectedNode.data.shape || [])}
+                          onBlur={(e) => {
                             try {
                               const newShape = JSON.parse(e.target.value);
                               if (Array.isArray(newShape) && newShape.every(item => typeof item === 'number')) {
                                 updateNodeData(selectedNode.id, { shape: newShape });
+                                return;
                               }
                             } catch (err) {
-                              // Invalid JSON, do nothing
+                              // fall through to reset below
+                            }
+                            // Invalid input: reset the field to the last valid shape
+                            e.target.value = JSON.stringify(selectedNode.data.shape || []);
+                          }}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter") {
+                              (e.target as HTMLInputElement).blur();
                             }
                           }}
                           placeholder="e.g., [1, 1, 768]"
@@ -2869,7 +3046,7 @@ export default function NeuralNetworkDesigner() {
                         value={selectedNode.data.hidden_size as number | undefined}
                         defaultValue={1}
                         min={1}
-                        onUpdate={(value) => updateNodeData(selectedNode.id, { hidden_sizen: value })}
+                        onUpdate={(value) => updateNodeData(selectedNode.id, { hidden_size: value })}
                       />
                       <EditableNumberInput
                         label="Number of Layers"

--- a/components/nodes/MultiheadAttentionNode.tsx
+++ b/components/nodes/MultiheadAttentionNode.tsx
@@ -1,5 +1,6 @@
 import { Handle, Position } from "@xyflow/react"
 import type { NodeData } from "@/lib/types"
+import { formatTensorShape } from "@/lib/tensor-shape-calculator"
 
 interface MultiheadAttentionNodeProps {
   data: NodeData
@@ -13,14 +14,10 @@ export function MultiheadAttentionNode({ data }: MultiheadAttentionNodeProps) {
       <Handle type="target" position={Position.Left} id="value" style={{ top: "75%" }} />
       <div className="text-center">
         <div className="font-semibold text-purple-800">MultiheadAttention</div>
-        <div className="text-xs text-purple-600 mt-1">Embed: {data.embed_dim || 512}</div>
+        <div className="text-xs text-purple-600 mt-1">Embed: {data.embed_dim || 128}</div>
         <div className="text-xs text-purple-600">Heads: {data.num_heads || 8}</div>
-        <div className="text-xs text-purple-600 mt-1">
-          In: {data.inputShape ? `[${Object.values(data.inputShape).join(",")}]` : "[?]"}
-        </div>
-        <div className="text-xs text-purple-600">
-          Out: {data.outputShape ? `[${Object.values(data.outputShape).join(",")}]` : "[?]"}
-        </div>
+        <div className="text-xs text-purple-600 mt-1">In: {formatTensorShape(data.inputShape)}</div>
+        <div className="text-xs text-purple-600">Out: {formatTensorShape(data.outputShape)}</div>
       </div>
       <Handle type="source" position={Position.Right} />
     </div>

--- a/components/nodes/SelectNode.tsx
+++ b/components/nodes/SelectNode.tsx
@@ -27,8 +27,8 @@ const selectNodeHelp: HelpContent = {
     {
       name: "dim",
       type: "number",
-      description: "Dimension along which to select. For example, dim=0 selects along the batch dimension.",
-      default: 0
+      description: "Dimension along which to select (1-based, excluding batch). For example, dim=1 selects along the first non-batch dimension.",
+      default: 1
     },
     {
       name: "index",
@@ -70,7 +70,7 @@ export function SelectNode({ data }: SelectNodeProps) {
           </TooltipProvider>
         </div>
         <div className="text-xs text-purple-600">
-          dim: {data.dim ?? 0}, idx: {data.index ?? 0}
+          dim: {data.dim ?? 1}, idx: {data.index ?? 0}
         </div>
         {data.inputShape && <div className="text-xs text-gray-500 mt-1">In: {formatTensorShape(data.inputShape)}</div>}
         {data.outputShape && <div className="text-xs text-gray-500">Out: {formatTensorShape(data.outputShape)}</div>}

--- a/lib/keyboard-shortcuts.ts
+++ b/lib/keyboard-shortcuts.ts
@@ -4,6 +4,7 @@ import { KeyboardShortcut } from "./types"
 export class KeyboardShortcutManager {
   private shortcuts: Map<string, KeyboardShortcut> = new Map()
   private isEnabled: boolean = true
+  private readonly boundHandleKeyDown = this.handleKeyDown.bind(this)
 
   constructor() {
     this.setupGlobalListener()
@@ -34,7 +35,7 @@ export class KeyboardShortcutManager {
   // Setup global keyboard listener
   private setupGlobalListener(): void {
     if (typeof document !== "undefined") {
-      document.addEventListener("keydown", this.handleKeyDown.bind(this))
+      document.addEventListener("keydown", this.boundHandleKeyDown)
     }
   }
 
@@ -50,7 +51,8 @@ export class KeyboardShortcutManager {
 
     const keyString = this.getKeyString({
       key: event.key,
-      ctrlKey: event.ctrlKey,
+      // Treat macOS Cmd as equivalent to Ctrl
+      ctrlKey: event.ctrlKey || event.metaKey,
       shiftKey: event.shiftKey,
       altKey: event.altKey,
       action: () => {},
@@ -77,7 +79,7 @@ export class KeyboardShortcutManager {
   // Cleanup
   destroy(): void {
     if (typeof document !== "undefined") {
-      document.removeEventListener("keydown", this.handleKeyDown.bind(this))
+      document.removeEventListener("keydown", this.boundHandleKeyDown)
     }
     this.shortcuts.clear()
   }
@@ -241,6 +243,13 @@ export const DEFAULT_SHORTCUTS: KeyboardShortcut[] = [
 export function useKeyboardShortcuts(shortcuts: KeyboardShortcut[] = []) {
   const [shortcutManager] = React.useState(() => new KeyboardShortcutManager())
 
+  // Destroy the manager (and its document listener) only on unmount
+  React.useEffect(() => {
+    return () => {
+      shortcutManager.destroy()
+    }
+  }, [shortcutManager])
+
   React.useEffect(() => {
     // Register default shortcuts
     DEFAULT_SHORTCUTS.forEach(shortcut => {
@@ -251,10 +260,6 @@ export function useKeyboardShortcuts(shortcuts: KeyboardShortcut[] = []) {
     shortcuts.forEach(shortcut => {
       shortcutManager.register(shortcut)
     })
-
-    return () => {
-      shortcutManager.destroy()
-    }
   }, [shortcutManager, shortcuts])
 
   return {

--- a/lib/model-analyzer.ts
+++ b/lib/model-analyzer.ts
@@ -20,6 +20,26 @@ export interface ModelAnalysis {
   estimatedInferenceTimeMs: number
 }
 
+// kernel_size may be a number, an array like [3, 3], or a string like "3,3".
+// Normalize to per-axis sizes so parameter/FLOP math never produces NaN.
+function parseKernelSizes(value: any, dims: number, defaultValue: number): number[] {
+  let parts: number[] = []
+  if (typeof value === "number" && !isNaN(value)) {
+    parts = [value]
+  } else if (Array.isArray(value)) {
+    parts = value.map(Number).filter((n) => !isNaN(n))
+  } else if (typeof value === "string") {
+    parts = value
+      .split(",")
+      .map((s) => parseInt(s.trim(), 10))
+      .filter((n) => !isNaN(n))
+  }
+  if (parts.length === 0) {
+    parts = [defaultValue]
+  }
+  return Array.from({ length: dims }, (_, i) => parts[i] ?? parts[0])
+}
+
 export function analyzeLayer(
   nodeType: string,
   nodeData: any,
@@ -43,16 +63,16 @@ export function analyzeLayer(
     case "depthwiseconv2dNode":
       const inChannels = nodeData.in_channels || 3
       const outChannels = nodeData.out_channels || 32
-      const kernelSize = nodeData.kernel_size || 3
+      const [kernelH, kernelW] = parseKernelSizes(nodeData.kernel_size, 2, 3)
       const groups = nodeData.groups || 1
 
       // Parameters: weights + bias
-      analysis.parameters = (inChannels * outChannels * kernelSize * kernelSize) / groups + outChannels
+      analysis.parameters = (inChannels * outChannels * kernelH * kernelW) / groups + outChannels
 
-      // FLOPs: for each output pixel, kernel_size^2 * in_channels * out_channels operations
+      // FLOPs: for each output pixel, kernel_h * kernel_w * in_channels * out_channels operations
       if (typeof outputShape.height === "number" && typeof outputShape.width === "number") {
         analysis.flops =
-          (batchSize * outputShape.height * outputShape.width * kernelSize * kernelSize * inChannels * outChannels) /
+          (batchSize * outputShape.height * outputShape.width * kernelH * kernelW * inChannels * outChannels) /
           groups
       }
 
@@ -76,7 +96,7 @@ export function analyzeLayer(
     case "conv1dNode":
       const conv1dIn = nodeData.in_channels || 1
       const conv1dOut = nodeData.out_channels || 32
-      const conv1dKernel = nodeData.kernel_size || 3
+      const [conv1dKernel] = parseKernelSizes(nodeData.kernel_size, 1, 3)
 
       analysis.parameters = conv1dIn * conv1dOut * conv1dKernel + conv1dOut
 
@@ -88,9 +108,9 @@ export function analyzeLayer(
     case "conv3dNode":
       const conv3dIn = nodeData.in_channels || 3
       const conv3dOut = nodeData.out_channels || 32
-      const conv3dKernel = nodeData.kernel_size || 3
+      const [conv3dKd, conv3dKh, conv3dKw] = parseKernelSizes(nodeData.kernel_size, 3, 3)
 
-      analysis.parameters = conv3dIn * conv3dOut * conv3dKernel * conv3dKernel * conv3dKernel + conv3dOut
+      analysis.parameters = conv3dIn * conv3dOut * conv3dKd * conv3dKh * conv3dKw + conv3dOut
 
       if (
         typeof outputShape.depth === "number" &&
@@ -102,9 +122,9 @@ export function analyzeLayer(
           outputShape.depth *
           outputShape.height *
           outputShape.width *
-          conv3dKernel *
-          conv3dKernel *
-          conv3dKernel *
+          conv3dKd *
+          conv3dKh *
+          conv3dKw *
           conv3dIn *
           conv3dOut
       }

--- a/lib/model-generator.ts
+++ b/lib/model-generator.ts
@@ -1,6 +1,15 @@
 
 import { type GraphIR, type GraphNode, type GraphEdge, PYTORCH_LAYER_MANIFEST } from "./types";
 
+// Node types handled inline in the forward pass rather than as nn.Module layers
+const FUNCTIONAL_NODE_TYPES = new Set([
+  "reshapeNode",
+  "addNode",
+  "multiplyNode",
+  "concatenateNode",
+  "transposeNode",
+]);
+
 export class ModelGenerator {
   private readonly nodes: GraphNode[];
   private readonly edges: GraphEdge[];
@@ -108,6 +117,7 @@ export class ModelGenerator {
     let classDefinition = `\n\nclass GeneratedModel(nn.Module):\n    def __init__(self):\n        super().__init__()\n`;
 
     const initLines: string[] = [];
+    const definedLayers = new Set<string>();
     for (const node of layerNodes) {
         const manifest = PYTORCH_LAYER_MANIFEST[node.type as keyof typeof PYTORCH_LAYER_MANIFEST];
         const layerName = this.sanitizeArgName(node.id);
@@ -115,7 +125,26 @@ export class ModelGenerator {
         if (manifest && manifest.className) {
             const params = this.buildParameterString(node, manifest.params);
             initLines.push(`        self.${layerName} = ${manifest.className}(${params})`);
-        } else if (!["reshapeNode", "addNode", "multiplyNode", "concatenateNode"].includes(node.type)) {
+            definedLayers.add(node.id);
+        } else if (node.type === "separableconv2dNode") {
+            const d = node.data as any;
+            const inCh = d.in_channels ?? 1;
+            const outCh = d.out_channels ?? 1;
+            const k = this.toPythonLiteral(d.kernel_size ?? 3);
+            const stride = this.toPythonLiteral(d.stride ?? 1);
+            const padding = this.toPythonLiteral(d.padding ?? 0);
+            initLines.push(
+                `        self.${layerName} = nn.Sequential(\n` +
+                `            nn.Conv2d(${inCh}, ${inCh}, kernel_size=${k}, stride=${stride}, padding=${padding}, groups=${inCh}),\n` +
+                `            nn.Conv2d(${inCh}, ${outCh}, kernel_size=1),\n` +
+                `        )`
+            );
+            definedLayers.add(node.id);
+        } else if (node.type === "parameterNode") {
+            const shape = Array.isArray((node.data as any).shape) ? (node.data as any).shape : [1];
+            initLines.push(`        self.${layerName} = nn.Parameter(torch.randn(${shape.join(", ")}))`);
+            definedLayers.add(node.id);
+        } else if (!FUNCTIONAL_NODE_TYPES.has(node.type) && node.type !== "constantNode") {
             console.warn(`Node type ${node.type} does not have a manifest entry and is not a recognized functional node.`);
         }
     }
@@ -126,21 +155,22 @@ export class ModelGenerator {
     const inputArgs = this.inputNodes.map((node) => this.sanitizeArgName(node.data.name || node.id)).join(", ");
     classDefinition += `    def forward(self, ${inputArgs}):\n`;
 
-    const forwardLinesResult = this.generateForwardPass(sortedNodes);
-    classDefinition += forwardLinesResult.map(line => `        ${line}`).join("\n");
+    const { lines: forwardLines, nodeOutputs } = this.generateForwardPass(sortedNodes, definedLayers);
+    classDefinition += forwardLines.map(line => `        ${line}`).join("\n");
 
     const outputNode = sortedNodes.find(n => n.type === 'outputNode');
     if (outputNode) {
         const finalEdge = this.edges.find(edge => edge.target === outputNode.id);
-        if (finalEdge) {
-            const finalOutputVar = this.sanitizeArgName(finalEdge.source);
+        const finalOutputVar = finalEdge ? nodeOutputs.get(finalEdge.source) : undefined;
+        if (finalOutputVar) {
             classDefinition += `\n        return ${finalOutputVar}`;
         } else {
             classDefinition += `\n        # No edge connected to output node\n        return None`;
         }
     } else {
         const lastNode = sortedNodes[sortedNodes.length - 1];
-        classDefinition += `\n        return ${this.sanitizeArgName(lastNode.id)}`;
+        const lastVar = nodeOutputs.get(lastNode.id) ?? this.sanitizeArgName(lastNode.id);
+        classDefinition += `\n        return ${lastVar}`;
     }
 
     code += classDefinition;
@@ -150,15 +180,11 @@ export class ModelGenerator {
       const inputVars = [];
       for (const inputNode of this.inputNodes) {
         const varName = this.sanitizeArgName(inputNode.data.name || inputNode.id);
-        const { channels, height, width, features } = inputNode.data;
-        let shape;
-        if (height !== undefined && width !== undefined) {
-          shape = `(1, ${channels}, ${height}, ${width})`;
-        } else if (features !== undefined) {
-          shape = `(1, ${features})`;
-        } else {
-          shape = `(1, ${channels})`;
-        }
+        const { channels, depth, height, width, sequence, length, features } = inputNode.data as any;
+        const dims = [channels, depth, height, width, sequence, length, features].filter(
+          (d) => typeof d === "number",
+        );
+        const shape = `(1${dims.map((d) => `, ${d}`).join("")})`;
         code += `# ${varName} = torch.randn${shape}\n`;
         inputVars.push(varName);
       }
@@ -173,19 +199,42 @@ export class ModelGenerator {
     for (const paramName of paramNames) {
         const value = node.data[paramName];
         if (value !== undefined && value !== null) {
-            if (Array.isArray(value)) {
-                params.push(`${paramName}=${JSON.stringify(value)}`);
-            } else if (typeof value === "string") {
-                params.push(`${paramName}="${value}"`);
-            } else {
-                params.push(`${paramName}=${value}`);
-            }
+            params.push(`${paramName}=${this.toPythonLiteral(value)}`);
         }
+    }
+    // Depthwise convolutions require groups=in_channels, which the manifest omits
+    if (node.type === "depthwiseconv2dNode" && node.data.in_channels !== undefined) {
+        params.push(`groups=${node.data.in_channels}`);
     }
     return params.join(", ");
   }
 
-  private generateForwardPass(sortedNodes: GraphNode[]): string[] {
+  private toPythonLiteral(value: any): string {
+    if (typeof value === "boolean") {
+        return value ? "True" : "False";
+    }
+    if (Array.isArray(value)) {
+        return `(${value.map((v) => this.toPythonLiteral(v)).join(", ")})`;
+    }
+    if (typeof value === "string") {
+        const trimmed = value.trim();
+        // Numeric strings (e.g. "3") and comma-separated tuples (e.g. "3, 3")
+        // come from free-form UI inputs and must not be quoted.
+        if (/^-?\d+(\.\d+)?$/.test(trimmed)) {
+            return trimmed;
+        }
+        if (/^-?\d+(\.\d+)?(\s*,\s*-?\d+(\.\d+)?)+$/.test(trimmed)) {
+            return `(${trimmed.split(",").map((s) => s.trim()).join(", ")})`;
+        }
+        return `"${trimmed}"`;
+    }
+    return `${value}`;
+  }
+
+  private generateForwardPass(
+    sortedNodes: GraphNode[],
+    definedLayers: Set<string>,
+  ): { lines: string[]; nodeOutputs: Map<string, string> } {
     const lines: string[] = [];
     const nodeOutputs = new Map<string, string>();
 
@@ -200,8 +249,31 @@ export class ModelGenerator {
         }
 
         const outputVar = this.sanitizeArgName(node.id);
+
+        // Source nodes produce a tensor without any inputs
+        if (node.type === "parameterNode") {
+            lines.push(`${outputVar} = self.${this.sanitizeArgName(node.id)}`);
+            nodeOutputs.set(node.id, outputVar);
+            continue;
+        }
+        if (node.type === "constantNode") {
+            const d = node.data as any;
+            const dims = [d.channels, d.depth, d.height, d.width, d.sequence, d.length, d.features]
+                .filter((v: any) => typeof v === "number");
+            lines.push(`${outputVar} = torch.zeros(1${dims.map((v: number) => `, ${v}`).join("")})`);
+            nodeOutputs.set(node.id, outputVar);
+            continue;
+        }
+
         const inputEdges = this.edges.filter(edge => edge.target === node.id);
-        const inputVars = inputEdges.map(edge => nodeOutputs.get(edge.source)!);
+        const inputVars = inputEdges
+            .map(edge => nodeOutputs.get(edge.source))
+            .filter((v): v is string => v !== undefined);
+
+        if (inputVars.length === 0) {
+            // Disconnected node: nothing to feed it, skip rather than emit broken code
+            continue;
+        }
 
         switch (node.type) {
             case "addNode":
@@ -210,22 +282,74 @@ export class ModelGenerator {
             case "multiplyNode":
                 lines.push(`${outputVar} = ${inputVars.join(" * ")}`);
                 break;
-            case "reshapeNode":
-                const shape = node.data.targetShape;
-                lines.push(`${outputVar} = ${inputVars[0]}.view(${inputVars[0]}.size(0), *${JSON.stringify(shape)})`);
+            case "reshapeNode": {
+                const shapeLiteral = this.formatTargetShape(node.data.targetShape);
+                lines.push(`${outputVar} = ${inputVars[0]}.view(${inputVars[0]}.size(0), *${shapeLiteral})`);
                 break;
-            case "concatenateNode":
-                const dim = node.data.dim || 1;
+            }
+            case "concatenateNode": {
+                const dim = node.data.dim ?? 1;
                 lines.push(`${outputVar} = torch.cat([${inputVars.join(", ")}], dim=${dim})`);
                 break;
-            default:
-                const layerName = this.sanitizeArgName(node.id);
-                lines.push(`${outputVar} = self.${layerName}(${inputVars.join(', ')})`);
+            }
+            case "transposeNode": {
+                // UI dims are 0-based over non-batch dims; tensor dim 0 is batch
+                const dim0 = Number(node.data.dim0 ?? 0) + 1;
+                const dim1 = Number(node.data.dim1 ?? 1) + 1;
+                lines.push(`${outputVar} = torch.transpose(${inputVars[0]}, ${dim0}, ${dim1})`);
                 break;
+            }
+            case "lstmNode":
+            case "gruNode":
+            case "rnnNode":
+                // Recurrent layers return (output, hidden-state) tuples
+                lines.push(`${outputVar}, _ = self.${this.sanitizeArgName(node.id)}(${inputVars[0]})`);
+                break;
+            case "multiheadattentionNode": {
+                // MultiheadAttention takes (query, key, value) and returns (output, weights).
+                // With a single input, use self-attention.
+                const layerName = this.sanitizeArgName(node.id);
+                const [q, k, v] = [
+                    inputVars[0],
+                    inputVars[1] ?? inputVars[0],
+                    inputVars[2] ?? inputVars[1] ?? inputVars[0],
+                ];
+                lines.push(`${outputVar}, _ = self.${layerName}(${q}, ${k}, ${v})`);
+                break;
+            }
+            default: {
+                const layerName = this.sanitizeArgName(node.id);
+                if (definedLayers.has(node.id)) {
+                    lines.push(`${outputVar} = self.${layerName}(${inputVars.join(', ')})`);
+                } else {
+                    // Unsupported node type: pass the input through so the code still runs
+                    lines.push(`${outputVar} = ${inputVars[0]}  # TODO: '${node.type}' is not supported by the code generator yet`);
+                }
+                break;
+            }
         }
         nodeOutputs.set(node.id, outputVar);
     }
-    return lines;
+    return { lines, nodeOutputs };
+  }
+
+  private formatTargetShape(targetShape: any): string {
+    let dims: number[] | null = null;
+    if (Array.isArray(targetShape)) {
+      dims = targetShape.map(Number).filter((n) => !isNaN(n));
+    } else if (typeof targetShape === "string") {
+      const cleaned = targetShape.replace(/[[\]()]/g, "").trim();
+      if (cleaned) {
+        const parsed = cleaned.split(",").map((s) => parseInt(s.trim(), 10));
+        if (parsed.every((n) => !isNaN(n))) {
+          dims = parsed;
+        }
+      }
+    }
+    if (!dims || dims.length === 0) {
+      return "(-1,)";
+    }
+    return `(${dims.join(", ")}${dims.length === 1 ? "," : ""})`;
   }
 
   private sanitizeArgName(name: string): string {

--- a/lib/model-validator.ts
+++ b/lib/model-validator.ts
@@ -151,7 +151,15 @@ export class ModelValidator {
       let inputShapes: (TensorShape | undefined)[] = []
 
       if (node.type === "concatenateNode" || node.type === "addNode" || node.type === "multiplyNode") {
-        const numInputs = Number(node.data.num_inputs ?? node.data.inputs ?? 2)
+        // Consider every connected inputN handle, not just a fixed count
+        const handleIndices = inputEdges
+          .map((e) => {
+            const match = /^input(\d+)$/.exec(e.targetHandle ?? "")
+            return match ? Number(match[1]) : 0
+          })
+          .filter((n) => n > 0)
+        const declaredInputs = Number(node.data.num_inputs ?? node.data.inputs ?? 2)
+        const numInputs = Math.max(declaredInputs, ...handleIndices, 2)
         for (let i = 1; i <= numInputs; i++) {
           const handleId = `input${i}`
           const edge = inputEdges.find((e) => e.targetHandle === handleId)

--- a/lib/tensor-shape-calculator.ts
+++ b/lib/tensor-shape-calculator.ts
@@ -35,6 +35,14 @@ function getOrderedDimensions(shape: TensorShape): (keyof TensorShape)[] {
     return CANONICAL_DIM_ORDER.filter(dim => shape[dim] !== undefined);
 }
 
+// Values of the non-batch dimensions of a shape. Shapes coming from node data may
+// carry a `batch` entry, which must never participate in feature/size math.
+function getFeatureDimValues(shape: TensorShape): (number | "dynamic")[] {
+    return CANONICAL_DIM_ORDER
+        .map(dim => shape[dim])
+        .filter((v): v is number | "dynamic" => typeof v === "number" || v === "dynamic");
+}
+
 export function validateTensorShapes(
   nodeType: string,
   inputShapes: (TensorShape | undefined)[], // Allow undefined for disconnected inputs
@@ -188,7 +196,7 @@ export function validateTensorShapes(
         return { isValid: false, error: "Invalid shape: can only have one '-1' dimension." };
       }
 
-      const inputDimValues = Object.values(inputShape).filter(v => typeof v === 'number' || v === 'dynamic');
+      const inputDimValues = getFeatureDimValues(inputShape);
       if (inputDimValues.some(v => v === "dynamic")) {
         if (targetDims.includes(-1)) {
           return { isValid: true, warning: "Cannot infer '-1' dimension when input shape is dynamic." };
@@ -233,24 +241,25 @@ export function validateTensorShapes(
       const in_features = nodeData.in_features;
       const inputShape = inputShapes[0];
       if (in_features && inputShape && Object.keys(inputShape).length > 0) {
-        const isDynamic = Object.values(inputShape).some(v => v === "dynamic");
+        const featureDims = getFeatureDimValues(inputShape);
+        const isDynamic = featureDims.some(v => v === "dynamic");
         if (isDynamic) {
             const dynamic_features = inputShape.features || inputShape.width || inputShape.channels;
             if (dynamic_features && dynamic_features !== 'dynamic' && in_features !== dynamic_features) {
                  return {
                     isValid: false,
-                    error: `Input features ${dynamic_features} do not match layer's in_features ${in_features}`,
+                    error: `Shape mismatch: input features ${dynamic_features} do not match layer's in_features ${in_features}`,
                 };
             }
         } else {
-            const totalInputFeatures = Object.values(inputShape)
+            const totalInputFeatures = featureDims
                 .filter((v): v is number => typeof v === 'number')
                 .reduce((acc, val) => acc * val, 1);
 
             if (totalInputFeatures > 0 && in_features !== totalInputFeatures) {
                 return {
                     isValid: false,
-                    error: `Input features ${totalInputFeatures} do not match layer's in_features ${in_features}`,
+                    error: `Shape mismatch: input features ${totalInputFeatures} do not match layer's in_features ${in_features}`,
                 };
             }
         }
@@ -358,6 +367,18 @@ export function calculateOutputShape(
         }
         return newShape;
       }
+
+    case "constantNode": {
+      // Constant is a source node: its shape comes from its own data fields
+      const constShape: TensorShape = {};
+      const constDims: (keyof TensorShape)[] = ["channels", "depth", "height", "width", "sequence", "length", "features"];
+      for (const dim of constDims) {
+        if (nodeData[dim] !== undefined) {
+          (constShape as any)[dim] = nodeData[dim];
+        }
+      }
+      return constShape;
+    }
 
     case "outputNode":
       // Output node is a sink; pass through the incoming shape unchanged
@@ -482,6 +503,71 @@ export function calculateOutputShape(
       }
       return { ...inputShape, channels: nodeData.out_channels || 16 };
 
+    case "convtranspose1dNode": {
+      const stride1d = nodeData.stride || 2;
+      const kernel1d = nodeData.kernel_size || 2;
+      const padding1d = nodeData.padding || 0;
+      const outPadding1d = nodeData.output_padding || 0;
+      const dilation1dT = nodeData.dilation || 1;
+
+      const lengthKey = inputShape.length !== undefined ? "length" : "width";
+      const inLength = inputShape[lengthKey];
+      if (inLength && typeof inLength === "number") {
+        const newLength =
+          (inLength - 1) * stride1d - 2 * padding1d + dilation1dT * (kernel1d - 1) + outPadding1d + 1;
+        const newShape: TensorShape = { ...inputShape };
+        newShape.channels = nodeData.out_channels || 16;
+        (newShape as any)[lengthKey] = isNaN(newLength) ? "dynamic" : Math.max(1, newLength);
+        return newShape;
+      }
+      return { ...inputShape, channels: nodeData.out_channels || 16 };
+    }
+
+    case "convtranspose3dNode": {
+      const stride3d = nodeData.stride || 2;
+      const kernel3d = nodeData.kernel_size || 2;
+      const padding3d = nodeData.padding || 0;
+      const outPadding3d = nodeData.output_padding || 0;
+      const dilation3dT = nodeData.dilation || 1;
+
+      const upsize = (v: number | "dynamic" | undefined): number | "dynamic" => {
+        if (typeof v !== "number") return "dynamic";
+        const out = (v - 1) * stride3d - 2 * padding3d + dilation3dT * (kernel3d - 1) + outPadding3d + 1;
+        return isNaN(out) ? "dynamic" : Math.max(1, out);
+      };
+
+      if (inputShape.depth && inputShape.height && inputShape.width) {
+        return {
+          channels: nodeData.out_channels || 16,
+          depth: upsize(inputShape.depth),
+          height: upsize(inputShape.height),
+          width: upsize(inputShape.width),
+        };
+      }
+      return { ...inputShape, channels: nodeData.out_channels || 16 };
+    }
+
+    case "mbconvNode": {
+      const mbStride = nodeData.stride || 1;
+      const mbKernel = typeof nodeData.kernel_size === "number" ? nodeData.kernel_size : 3;
+      const mbPadding = Math.floor(mbKernel / 2); // MBConv uses "same" padding on the depthwise conv
+
+      if (inputShape.height && inputShape.width && mbStride > 0) {
+        const newHeight = Math.floor(
+          (Number(inputShape.height) + 2 * mbPadding - (mbKernel - 1) - 1) / mbStride + 1,
+        );
+        const newWidth = Math.floor(
+          (Number(inputShape.width) + 2 * mbPadding - (mbKernel - 1) - 1) / mbStride + 1,
+        );
+        return {
+          channels: nodeData.out_channels,
+          height: isNaN(newHeight) ? "dynamic" : Math.max(1, newHeight),
+          width: isNaN(newWidth) ? "dynamic" : Math.max(1, newWidth),
+        };
+      }
+      return { ...inputShape, channels: nodeData.out_channels };
+    }
+
     case "upsampleNode": {
       const scaleFactor = nodeData.scale_factor || 2;
       if (inputShape.height && inputShape.width) {
@@ -593,7 +679,7 @@ export function calculateOutputShape(
             1,
         );
         return {
-          channels: nodeData.out_channels || 32,
+          channels: inputShape.channels,
           depth: isNaN(newDepth) ? "dynamic" : Math.max(1, newDepth),
           height: isNaN(newHeight) ? "dynamic" : Math.max(1, newHeight),
           width: isNaN(newWidth) ? "dynamic" : Math.max(1, newWidth),
@@ -741,7 +827,7 @@ export function calculateOutputShape(
 
       // If input shape is present, validate and infer the -1 dimension
       if (inputShape && Object.keys(inputShape).length > 0) {
-        const inputDimValues = Object.values(inputShape).filter(v => typeof v === 'number' || v === 'dynamic');
+        const inputDimValues = getFeatureDimValues(inputShape);
 
         if (inputDimValues.some(v => v === "dynamic")) {
           finalDims = targetDims.map(d => (d === -1 ? "dynamic" : d));

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -263,6 +263,38 @@ export const PYTORCH_LAYER_MANIFEST = {
     className: "nn.AvgPool3d",
     params: ["kernel_size", "stride", "padding", "ceil_mode", "count_include_pad", "divisor_override"]
   },
+  adaptiveavgpool1dNode: {
+    className: "nn.AdaptiveAvgPool1d",
+    params: ["output_size"]
+  },
+  adaptiveavgpool2dNode: {
+    className: "nn.AdaptiveAvgPool2d",
+    params: ["output_size"]
+  },
+  adaptiveavgpool3dNode: {
+    className: "nn.AdaptiveAvgPool3d",
+    params: ["output_size"]
+  },
+  adaptivemaxpool1dNode: {
+    className: "nn.AdaptiveMaxPool1d",
+    params: ["output_size"]
+  },
+  adaptivemaxpool2dNode: {
+    className: "nn.AdaptiveMaxPool2d",
+    params: ["output_size"]
+  },
+  adaptivemaxpool3dNode: {
+    className: "nn.AdaptiveMaxPool3d",
+    params: ["output_size"]
+  },
+  lppool2dNode: {
+    className: "nn.LPPool2d",
+    params: ["norm_type", "kernel_size", "stride", "ceil_mode"]
+  },
+  fractionalmaxpool2dNode: {
+    className: "nn.FractionalMaxPool2d",
+    params: ["kernel_size", "output_size", "output_ratio", "return_indices"]
+  },
   batchnorm1dNode: {
     className: "nn.BatchNorm1d",
     params: ["num_features", "eps", "momentum", "affine", "track_running_stats"]
@@ -323,8 +355,28 @@ export const PYTORCH_LAYER_MANIFEST = {
     className: "nn.GELU",
     params: []
   },
+  siluNode: {
+    className: "nn.SiLU",
+    params: ["inplace"]
+  },
+  mishNode: {
+    className: "nn.Mish",
+    params: ["inplace"]
+  },
+  hardswishNode: {
+    className: "nn.Hardswish",
+    params: ["inplace"]
+  },
+  hardsigmoidNode: {
+    className: "nn.Hardsigmoid",
+    params: ["inplace"]
+  },
   softmaxNode: {
     className: "nn.Softmax",
+    params: ["dim"]
+  },
+  logsoftmaxNode: {
+    className: "nn.LogSoftmax",
     params: ["dim"]
   },
   dropoutNode: {

--- a/lib/undo-redo.ts
+++ b/lib/undo-redo.ts
@@ -18,6 +18,18 @@ export class UndoRedoManager {
       timestamp: Date.now(),
     };
 
+    // Skip if identical to the current state (e.g. node + edge removal in the
+    // same tick both snapshot the same pre-delete state, which would make the
+    // user press Undo twice to see a change)
+    const current = this.getCurrentState();
+    if (
+      current &&
+      JSON.stringify(current.nodes) === JSON.stringify(newState.nodes) &&
+      JSON.stringify(current.edges) === JSON.stringify(newState.edges)
+    ) {
+      return;
+    }
+
     // Remove any states after current index (when branching from history)
     this.history = this.history.slice(0, this.currentIndex + 1);
 
@@ -133,6 +145,16 @@ export function useUndoRedo(initialNodes: any[] = [], initialEdges: any[] = []) 
     }
   }, []);
 
+  // Replace the whole history with a single baseline state (e.g. after
+  // restoring a saved session) so Undo cannot step back past it.
+  const resetHistory = React.useCallback((newNodes: any[], newEdges: any[]) => {
+    undoRedoManager.current.clear();
+    undoRedoManager.current.saveState(newNodes, newEdges);
+    setNodes(newNodes);
+    setEdges(newEdges);
+    setHistoryInfo(undoRedoManager.current.getHistoryInfo());
+  }, []);
+
   return {
     nodes,
     setNodes,
@@ -141,6 +163,7 @@ export function useUndoRedo(initialNodes: any[] = [], initialEdges: any[] = []) 
     undo,
     redo,
     takeSnapshot,
+    resetHistory,
     canUndo: historyInfo.canUndo,
     canRedo: historyInfo.canRedo,
   };

--- a/lib/visualization-generator.tsx
+++ b/lib/visualization-generator.tsx
@@ -1,5 +1,25 @@
 import { type GraphIR, type GraphNode, type GraphEdge, PYTORCH_LAYER_MANIFEST } from "./types"
 
+// Normalize a kernel/stride/padding value (number, [h, w] array, or "h,w"
+// string) to an [h, w] pair so the arithmetic below never produces NaN.
+function toScalarPair(value: any, defaultValue: number): [number, number] {
+  if (typeof value === "number" && !isNaN(value)) return [value, value]
+  if (Array.isArray(value)) {
+    const nums = value.map(Number).filter((n) => !isNaN(n))
+    if (nums.length >= 2) return [nums[0], nums[1]]
+    if (nums.length === 1) return [nums[0], nums[0]]
+  }
+  if (typeof value === "string") {
+    const nums = value
+      .split(",")
+      .map((s) => parseInt(s.trim(), 10))
+      .filter((n) => !isNaN(n))
+    if (nums.length >= 2) return [nums[0], nums[1]]
+    if (nums.length === 1) return [nums[0], nums[0]]
+  }
+  return [defaultValue, defaultValue]
+}
+
 export interface VisualizationLayer {
   id: string
   name: string
@@ -32,13 +52,27 @@ export class VisualizationGenerator {
     this.inputNode = this.nodes.find((node) => node.type === "inputNode") || null
   }
 
+  // Input nodes store their dimensions as individual fields (channels/height/
+  // width/features), not as a `shape` array — build the array from those.
+  private getInputShapeArray(node: GraphNode | null): number[] {
+    if (!node) return []
+    if (Array.isArray(node.data.shape)) return node.data.shape
+    const { channels, depth, height, width, sequence, length, features } = node.data as any
+    const dims = [channels, depth, height, width, sequence, length, features].filter(
+      (v): v is number => typeof v === "number",
+    )
+    // Leading batch dimension for display purposes
+    return dims.length > 0 ? [1, ...dims] : []
+  }
+
   // Calculate tensor shapes through the network
   private calculateTensorShapes(): Map<string, number[]> {
     const shapes = new Map<string, number[]>()
 
     // Start with input shape
-    if (this.inputNode?.data.shape) {
-      shapes.set(this.inputNode.id, this.inputNode.data.shape)
+    const inputShapeArray = this.getInputShapeArray(this.inputNode)
+    if (this.inputNode && inputShapeArray.length > 0) {
+      shapes.set(this.inputNode.id, inputShapeArray)
     }
 
     // Topologically sort nodes
@@ -70,28 +104,30 @@ export class VisualizationGenerator {
         // Linear layer: [batch, in_features] -> [batch, out_features]
         return [inputShape[0], node.data.out_features || inputShape[1]]
 
-      case "conv2dNode":
+      case "conv2dNode": {
         // Conv2D: [batch, in_channels, height, width] -> [batch, out_channels, new_height, new_width]
         if (inputShape.length !== 4) return inputShape
-        const kernel = node.data.kernel_size || 3
-        const stride = node.data.stride || 1
-        const padding = node.data.padding || 0
-        const newHeight = Math.floor((inputShape[2] + 2 * padding - kernel) / stride + 1)
-        const newWidth = Math.floor((inputShape[3] + 2 * padding - kernel) / stride + 1)
+        const [kernelH, kernelW] = toScalarPair(node.data.kernel_size, 3)
+        const [strideH, strideW] = toScalarPair(node.data.stride, 1)
+        const [padH, padW] = toScalarPair(node.data.padding, 0)
+        const newHeight = Math.floor((inputShape[2] + 2 * padH - kernelH) / strideH + 1)
+        const newWidth = Math.floor((inputShape[3] + 2 * padW - kernelW) / strideW + 1)
         return [inputShape[0], node.data.out_channels || inputShape[1], newHeight, newWidth]
+      }
 
-      case "maxpool2dNode":
+      case "maxpool2dNode": {
         // MaxPool2D: reduces spatial dimensions
         if (inputShape.length !== 4) return inputShape
-        const poolKernel = node.data.kernel_size || 2
-        const poolStride = node.data.stride || poolKernel
-        const pooledHeight = Math.floor((inputShape[2] - poolKernel) / poolStride + 1)
-        const pooledWidth = Math.floor((inputShape[3] - poolKernel) / poolStride + 1)
+        const [poolKernelH, poolKernelW] = toScalarPair(node.data.kernel_size, 2)
+        const [poolStrideH, poolStrideW] = toScalarPair(node.data.stride ?? node.data.kernel_size, 2)
+        const pooledHeight = Math.floor((inputShape[2] - poolKernelH) / poolStrideH + 1)
+        const pooledWidth = Math.floor((inputShape[3] - poolKernelW) / poolStrideW + 1)
         return [inputShape[0], inputShape[1], pooledHeight, pooledWidth]
+      }
 
       case "flattenNode":
         // Flatten: [batch, ...] -> [batch, flattened_size]
-        const startDim = node.data.start_dim || 1
+        const startDim = node.data.start_dim ?? 1
         const flattenedSize = inputShape.slice(startDim).reduce((a, b) => a * b, 1)
         return [inputShape[0], flattenedSize]
 
@@ -170,7 +206,10 @@ export class VisualizationGenerator {
 
     for (let i = 0; i < sortedNodes.length; i++) {
       const node = sortedNodes[i]
-      const inputShape = i > 0 ? shapes.get(sortedNodes[i - 1].id) : undefined
+      // Input shape comes from the node's actual predecessor in the graph,
+      // not from whichever node happens to precede it in topological order
+      const incomingEdge = this.edges.find((edge) => edge.target === node.id)
+      const inputShape = incomingEdge ? shapes.get(incomingEdge.source) : undefined
       const outputShape = shapes.get(node.id)
 
       layers.push({
@@ -197,7 +236,7 @@ export class VisualizationGenerator {
     return {
       layers,
       connections,
-      inputShape: this.inputNode?.data.shape || [],
+      inputShape: this.getInputShapeArray(this.inputNode),
     }
   }
 

--- a/tests/model-generator.test.ts
+++ b/tests/model-generator.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from 'vitest';
+import { ModelGenerator } from '../lib/model-generator';
+import type { GraphNode, GraphEdge } from '../lib/types';
+
+function makeGraph(nodes: GraphNode[], edges: GraphEdge[]) {
+    return new ModelGenerator({ nodes, edges });
+}
+
+const inputNode = (id = 'input1', data: any = { name: 'x', channels: 3, height: 28, width: 28 }): GraphNode => ({
+    id,
+    type: 'inputNode',
+    data,
+});
+
+describe('ModelGenerator', () => {
+    it('generates a simple linear model', () => {
+        const code = makeGraph(
+            [
+                inputNode('input1', { name: 'x', features: 784 }),
+                { id: 'fc1', type: 'linearNode', data: { in_features: 784, out_features: 128 } },
+            ],
+            [{ id: 'e1', source: 'input1', target: 'fc1' }],
+        ).generateCode();
+
+        expect(code).toContain('self.fc1 = nn.Linear(in_features=784, out_features=128)');
+        expect(code).toContain('fc1 = self.fc1(x)');
+        expect(code).toContain('return fc1');
+    });
+
+    it('emits Python booleans (True/False), not JS booleans', () => {
+        const code = makeGraph(
+            [
+                inputNode('input1', { name: 'x', features: 784 }),
+                { id: 'fc1', type: 'linearNode', data: { in_features: 784, out_features: 128, bias: false } },
+            ],
+            [{ id: 'e1', source: 'input1', target: 'fc1' }],
+        ).generateCode();
+
+        expect(code).toContain('bias=False');
+        expect(code).not.toContain('bias=false');
+    });
+
+    it('unpacks LSTM tuple outputs in the forward pass', () => {
+        const code = makeGraph(
+            [
+                inputNode('input1', { name: 'x', sequence: 10, features: 32 }),
+                { id: 'lstm1', type: 'lstmNode', data: { input_size: 32, hidden_size: 64, batch_first: true } },
+            ],
+            [{ id: 'e1', source: 'input1', target: 'lstm1' }],
+        ).generateCode();
+
+        expect(code).toContain('lstm1, _ = self.lstm1(x)');
+        expect(code).toContain('batch_first=True');
+    });
+
+    it('calls MultiheadAttention with query/key/value and unpacks the tuple', () => {
+        const code = makeGraph(
+            [
+                inputNode('input1', { name: 'x', sequence: 10, features: 128 }),
+                { id: 'attn1', type: 'multiheadattentionNode', data: { embed_dim: 128, num_heads: 8 } },
+            ],
+            [{ id: 'e1', source: 'input1', target: 'attn1' }],
+        ).generateCode();
+
+        expect(code).toContain('attn1, _ = self.attn1(x, x, x)');
+    });
+
+    it('parses string targetShape for reshape nodes into a tuple literal', () => {
+        const code = makeGraph(
+            [
+                inputNode('input1', { name: 'x', channels: 1, height: 28, width: 28 }),
+                { id: 'reshape1', type: 'reshapeNode', data: { targetShape: '[-1, 784]' } },
+            ],
+            [{ id: 'e1', source: 'input1', target: 'reshape1' }],
+        ).generateCode();
+
+        expect(code).toContain('reshape1 = x.view(x.size(0), *(-1, 784))');
+        expect(code).not.toContain('*"');
+    });
+
+    it('adds groups=in_channels for depthwise convolutions', () => {
+        const code = makeGraph(
+            [
+                inputNode(),
+                { id: 'dw1', type: 'depthwiseconv2dNode', data: { in_channels: 32, out_channels: 32, kernel_size: 3 } },
+            ],
+            [{ id: 'e1', source: 'input1', target: 'dw1' }],
+        ).generateCode();
+
+        expect(code).toContain('groups=32');
+    });
+
+    it('expands separable convolutions into depthwise + pointwise', () => {
+        const code = makeGraph(
+            [
+                inputNode(),
+                { id: 'sep1', type: 'separableconv2dNode', data: { in_channels: 3, out_channels: 64, kernel_size: 3 } },
+            ],
+            [{ id: 'e1', source: 'input1', target: 'sep1' }],
+        ).generateCode();
+
+        expect(code).toContain('nn.Sequential');
+        expect(code).toContain('groups=3');
+        expect(code).toContain('kernel_size=1');
+        expect(code).toContain('sep1 = self.sep1(x)');
+    });
+
+    it('does not call undefined layers for unsupported node types', () => {
+        const code = makeGraph(
+            [
+                inputNode(),
+                { id: 'mystery1', type: 'someUnknownNode', data: {} },
+            ],
+            [{ id: 'e1', source: 'input1', target: 'mystery1' }],
+        ).generateCode();
+
+        expect(code).not.toContain('self.mystery1(');
+        expect(code).toContain("# TODO: 'someUnknownNode' is not supported");
+    });
+
+    it('emits tuple literals for comma-separated string parameters', () => {
+        const code = makeGraph(
+            [
+                inputNode(),
+                { id: 'conv1', type: 'conv2dNode', data: { in_channels: 3, out_channels: 16, kernel_size: '3, 3' } },
+            ],
+            [{ id: 'e1', source: 'input1', target: 'conv1' }],
+        ).generateCode();
+
+        expect(code).toContain('kernel_size=(3, 3)');
+        expect(code).not.toContain('kernel_size="');
+    });
+
+    it('resolves the return variable through the output node', () => {
+        const code = makeGraph(
+            [
+                inputNode('input1', { name: 'x', features: 10 }),
+                { id: 'fc1', type: 'linearNode', data: { in_features: 10, out_features: 2 } },
+                { id: 'out1', type: 'outputNode', data: {} },
+            ],
+            [
+                { id: 'e1', source: 'input1', target: 'fc1' },
+                { id: 'e2', source: 'fc1', target: 'out1' },
+            ],
+        ).generateCode();
+
+        expect(code).toContain('return fc1');
+    });
+
+    it('returns the named input variable when the output node is fed directly by an input', () => {
+        const code = makeGraph(
+            [
+                inputNode('input1', { name: 'x', features: 10 }),
+                { id: 'out1', type: 'outputNode', data: {} },
+            ],
+            [{ id: 'e1', source: 'input1', target: 'out1' }],
+        ).generateCode();
+
+        expect(code).toContain('return x');
+    });
+
+    it('emits nn.Parameter for parameter source nodes', () => {
+        const code = makeGraph(
+            [
+                inputNode('input1', { name: 'x', sequence: 4, features: 8 }),
+                { id: 'pos_emb', type: 'parameterNode', data: { shape: [1, 4, 8] } },
+                { id: 'add1', type: 'addNode', data: {} },
+            ],
+            [
+                { id: 'e1', source: 'input1', target: 'add1' },
+                { id: 'e2', source: 'pos_emb', target: 'add1' },
+            ],
+        ).generateCode();
+
+        expect(code).toContain('self.pos_emb = nn.Parameter(torch.randn(1, 4, 8))');
+        expect(code).toContain('pos_emb = self.pos_emb');
+        expect(code).toMatch(/add1 = .*\+.*/);
+    });
+
+    it('emits torch.zeros for constant source nodes', () => {
+        const code = makeGraph(
+            [
+                inputNode('input1', { name: 'x', channels: 1, height: 4, width: 4 }),
+                { id: 'const1', type: 'constantNode', data: { channels: 1, height: 4, width: 4 } },
+                { id: 'add1', type: 'addNode', data: {} },
+            ],
+            [
+                { id: 'e1', source: 'input1', target: 'add1' },
+                { id: 'e2', source: 'const1', target: 'add1' },
+            ],
+        ).generateCode();
+
+        expect(code).toContain('const1 = torch.zeros(1, 1, 4, 4)');
+    });
+
+    it('rejects graphs without an input node', () => {
+        const generator = makeGraph(
+            [{ id: 'fc1', type: 'linearNode', data: { in_features: 4, out_features: 2 } }],
+            [],
+        );
+        expect(() => generator.generateCode()).toThrow(/input node/i);
+    });
+
+    it('rejects cyclic graphs', () => {
+        const generator = makeGraph(
+            [
+                inputNode(),
+                { id: 'a', type: 'linearNode', data: { in_features: 4, out_features: 4 } },
+                { id: 'b', type: 'linearNode', data: { in_features: 4, out_features: 4 } },
+            ],
+            [
+                { id: 'e1', source: 'input1', target: 'a' },
+                { id: 'e2', source: 'a', target: 'b' },
+                { id: 'e3', source: 'b', target: 'a' },
+            ],
+        );
+        expect(() => generator.generateCode()).toThrow(/cycle/i);
+    });
+});

--- a/tests/tensor-shape-calculator.test.ts
+++ b/tests/tensor-shape-calculator.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { calculateOutputShape, validateTensorShapes, formatTensorShape } from '../lib/tensor-shape-calculator';
+
+describe('validateTensorShapes', () => {
+    it('ignores the batch dimension when validating linear in_features', () => {
+        const result = validateTensorShapes(
+            'linearNode',
+            [{ batch: 32, features: 784 } as any],
+            { in_features: 784, out_features: 128 },
+        );
+        expect(result.isValid).toBe(true);
+    });
+
+    it('reports a mismatch for wrong linear in_features', () => {
+        const result = validateTensorShapes(
+            'linearNode',
+            [{ features: 784 }],
+            { in_features: 512, out_features: 128 },
+        );
+        expect(result.isValid).toBe(false);
+        expect(result.error).toMatch(/mismatch/i);
+    });
+
+    it('flattens multi-dim input when validating linear in_features', () => {
+        const result = validateTensorShapes(
+            'linearNode',
+            [{ channels: 16, height: 4, width: 4 }],
+            { in_features: 256, out_features: 10 },
+        );
+        expect(result.isValid).toBe(true);
+    });
+
+    it('accepts broadcast-compatible add inputs', () => {
+        const result = validateTensorShapes(
+            'addNode',
+            [{ channels: 64, height: 8, width: 8 }, { channels: 64, height: 8, width: 8 }],
+            {},
+        );
+        expect(result.isValid).toBe(true);
+    });
+
+    it('rejects incompatible add inputs', () => {
+        const result = validateTensorShapes(
+            'addNode',
+            [{ channels: 64, height: 8, width: 8 }, { channels: 32, height: 8, width: 8 }],
+            {},
+        );
+        expect(result.isValid).toBe(false);
+    });
+});
+
+describe('calculateOutputShape', () => {
+    it('preserves channels through MaxPool3d', () => {
+        const out = calculateOutputShape(
+            'maxpool3dNode',
+            [{ channels: 8, depth: 16, height: 16, width: 16 }],
+            { kernel_size: 2 },
+        );
+        expect(out.channels).toBe(8);
+        expect(out.depth).toBe(8);
+        expect(out.height).toBe(8);
+        expect(out.width).toBe(8);
+    });
+
+    it('computes constantNode shape from its own data', () => {
+        const out = calculateOutputShape('constantNode', [], { channels: 1, height: 4, width: 4 });
+        expect(out).toEqual({ channels: 1, height: 4, width: 4 });
+    });
+
+    it('upsamples length for ConvTranspose1d', () => {
+        const out = calculateOutputShape(
+            'convtranspose1dNode',
+            [{ channels: 16, length: 10 }],
+            { out_channels: 8, kernel_size: 2, stride: 2 },
+        );
+        expect(out.channels).toBe(8);
+        expect(out.length).toBe(20);
+    });
+
+    it('upsamples depth/height/width for ConvTranspose3d', () => {
+        const out = calculateOutputShape(
+            'convtranspose3dNode',
+            [{ channels: 16, depth: 4, height: 4, width: 4 }],
+            { out_channels: 8, kernel_size: 2, stride: 2 },
+        );
+        expect(out).toEqual({ channels: 8, depth: 8, height: 8, width: 8 });
+    });
+
+    it('applies out_channels and stride for MBConv blocks', () => {
+        const out = calculateOutputShape(
+            'mbconvNode',
+            [{ channels: 32, height: 112, width: 112 }],
+            { in_channels: 32, out_channels: 96, kernel_size: 3, stride: 2, expand_ratio: 6 },
+        );
+        expect(out.channels).toBe(96);
+        expect(out.height).toBe(56);
+        expect(out.width).toBe(56);
+    });
+
+    it('conv2d computes spatial dims with tuple string kernels', () => {
+        const out = calculateOutputShape(
+            'conv2dNode',
+            [{ channels: 3, height: 28, width: 28 }],
+            { out_channels: 16, kernel_size: '3,3', stride: 1, padding: 1 },
+        );
+        expect(out).toEqual({ channels: 16, height: 28, width: 28 });
+    });
+});
+
+describe('formatTensorShape', () => {
+    it('formats canonical dims in order', () => {
+        expect(formatTensorShape({ channels: 3, height: 28, width: 28 })).toBe('[3, 28, 28]');
+    });
+
+    it('renders dynamic dims as ?', () => {
+        expect(formatTensorShape({ channels: 3, height: 'dynamic', width: 28 })).toBe('[3, ?, 28]');
+    });
+
+    it('handles empty shapes', () => {
+        expect(formatTensorShape({})).toBe('[?]');
+        expect(formatTensorShape(undefined)).toBe('[?]');
+    });
+});


### PR DESCRIPTION
## Summary

A full bug-hunting pass over the library, API routes, and UI, followed by a set of usability features. All 38 tests pass (2 previously failing tests now fixed), `tsc --noEmit` is clean, and `next build` succeeds.

## Bug fixes

### Code generator (`lib/model-generator.ts`)
- Booleans now emit as Python `True`/`False` instead of `true`/`false` (previously generated invalid Python for any layer with `bias=false` etc.)
- LSTM/GRU/RNN and MultiheadAttention outputs are tuple-unpacked (`x, _ = self.lstm(x)`); attention is called with `(query, key, value)`
- Reshape nodes parse string `targetShape` (`"[-1, 784]"`) into a tuple literal instead of unpacking a string character-by-character
- Depthwise convolutions get `groups=in_channels`; separable convolutions expand into depthwise + pointwise `nn.Sequential`
- `parameterNode`/`constantNode` source nodes emit `nn.Parameter(torch.randn(...))` / `torch.zeros(...)` instead of calls to undefined layers
- Unsupported node types now pass their input through with a TODO comment instead of emitting `self.layer(...)` calls that raise `AttributeError`
- Comma-separated string params (`"3, 3"`) emit as tuples; return variable resolves correctly when the output node is fed directly by a named input

### Shape validation & calculation (`lib/tensor-shape-calculator.ts`, `lib/model-validator.ts`)
- The batch dimension is excluded from linear/reshape feature products — this caused false "shape mismatch" errors (and the 2 failing tests)
- MaxPool3d/AvgPool3d preserve channel count instead of overwriting it with `out_channels || 32`
- Added missing output-shape cases: `mbconvNode`, `convtranspose1dNode`, `convtranspose3dNode`, `constantNode` (these silently passed input shapes through, corrupting all downstream shapes)
- Add/Multiply/Concatenate validation now checks **all** connected `inputN` handles, not just the first two

### Model analyzer & visualization (`lib/model-analyzer.ts`, `lib/visualization-generator.tsx`)
- Tuple/string `kernel_size` values (`[3,3]`, `"3,3"`) no longer poison total parameter/FLOP counts with `NaN`
- Visualization reads input dims from the node's actual fields (it previously read a nonexistent `data.shape`, so every shape rendered blank) and takes each layer's input shape from its real graph predecessor instead of topological-order neighbors

### UI (`app/page.tsx`, node components, `lib/keyboard-shortcuts.ts`, `lib/undo-redo.ts`)
- Fixed `hidden_sizen` typo — GRU hidden-size edits were silently discarded
- Deleting a node no longer requires pressing Undo twice (duplicate snapshots are skipped)
- Restored sessions are seeded into undo history, so the first undo can't wipe out the whole restored canvas
- Keyboard shortcut manager: fixed `removeEventListener` leak, added macOS Cmd support, stopped destroying the manager on every re-render
- Cleared stale node selection after import/load/code-parse; real server error messages surface in the generation-failed toast
- Registered 6 existing but unmapped node components (MaxPool1D/3D, BatchNorm3D, FractionalMaxPool2D, LPPool2D, AdaptiveMaxPool1D)
- Parameter-node Shape input no longer resets while typing (commits on blur/Enter)
- SelectNode default dim now matches the shape engine; MultiheadAttention node shows correct defaults and ordered shapes
- Added manifest entries for SiLU/Mish/Hardswish/Hardsigmoid/LogSoftmax/adaptive pools/LPPool2d/FractionalMaxPool2d so these generate real code

### API routes
- Example-file route canonicalizes the resolved path against the examples directory (proper traversal guard instead of a `..` substring check)
- Graph routes validate `nodes`/`edges` are arrays and return 400 instead of crashing to 500

## Features
- **Working keyboard shortcuts**: Ctrl+S/O/N/Z/Y/G/R/A/D/F and H now actually do things (they were displayed in Help but never wired up)
- **Copy / Cut / Paste** selected nodes (Ctrl+C/X/V) with internal-edge remapping and offset placement
- **Import Code button** — the PyTorch code-import dialog existed but was unreachable from the UI
- **Duplicate Node** button in the properties panel
- **Live parameter-count badge** in the header
- **New test suites**: `tests/model-generator.test.ts` (15 tests) and `tests/tensor-shape-calculator.test.ts` (14 tests)

## Verification
- `vitest run`: 38/38 passing (was 7/9)
- `tsc --noEmit`: clean
- `next build`: succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013bvg5Q4aGGRXHsPkN32NHR

---
_Generated by [Claude Code](https://claude.ai/code/session_013bvg5Q4aGGRXHsPkN32NHR)_