### PR TITLE
Fix nn.Linear shape semantics: apply to the last dimension only (issue #5)

### DIFF
--- a/app/api/examples/[...filename]/route.ts
+++ b/app/api/examples/[...filename]/route.ts
@@ -4,9 +4,10 @@ import path from 'path';
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { filename: string[] } }
+  { params }: { params: Promise<{ filename: string[] }> }
 ) {
-  const filename = params.filename.join('/');
+  const { filename: filenameParts } = await params;
+  const filename = filenameParts.join('/');
 
   // Prevent path traversal: resolve and verify the path stays inside the
   // examples directory instead of relying on a substring blocklist

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -554,19 +554,16 @@ export default function NeuralNetworkDesigner() {
         }
 
         if (node.type === "linearNode" && firstInputShape) {
-            if (typeof firstInputShape.features === "number") {
-                data.in_features = firstInputShape.features;
-            } else if (firstInputShape.features === undefined) {
-                const prevNode = nodeMap.get(inputEdges[0]?.source);
-                const isPrevNodeFlattenOrPool = prevNode && (prevNode.type === 'flattenNode' || prevNode.type?.includes('pool'));
-
-                if (isPrevNodeFlattenOrPool || firstInputShape.channels) { 
-                    const c = typeof firstInputShape.channels === 'number' ? firstInputShape.channels : 1;
-                    const h = typeof firstInputShape.height === 'number' ? firstInputShape.height : 1;
-                    const w = typeof firstInputShape.width === 'number' ? firstInputShape.width : 1;
-                    const flattenedSize = c * h * w;
-                    data.in_features = flattenedSize;
-                }
+            // nn.Linear applies to the LAST dimension only: (*, H_in) -> (*, H_out),
+            // so in_features must track the input's last dimension — not the
+            // flattened product of all dimensions (see issue #5)
+            const linearDimOrder: (keyof TensorShape)[] = [
+                "features", "length", "sequence", "width", "height", "depth", "channels",
+            ];
+            const lastDimKey = linearDimOrder.find((d) => (firstInputShape as any)[d] !== undefined);
+            const lastDimValue = lastDimKey ? (firstInputShape as any)[lastDimKey] : undefined;
+            if (typeof lastDimValue === "number") {
+                data.in_features = lastDimValue;
             }
         }
 

--- a/lib/tensor-shape-calculator.ts
+++ b/lib/tensor-shape-calculator.ts
@@ -241,27 +241,15 @@ export function validateTensorShapes(
       const in_features = nodeData.in_features;
       const inputShape = inputShapes[0];
       if (in_features && inputShape && Object.keys(inputShape).length > 0) {
-        const featureDims = getFeatureDimValues(inputShape);
-        const isDynamic = featureDims.some(v => v === "dynamic");
-        if (isDynamic) {
-            const dynamic_features = inputShape.features || inputShape.width || inputShape.channels;
-            if (dynamic_features && dynamic_features !== 'dynamic' && in_features !== dynamic_features) {
-                 return {
-                    isValid: false,
-                    error: `Shape mismatch: input features ${dynamic_features} do not match layer's in_features ${in_features}`,
-                };
-            }
-        } else {
-            const totalInputFeatures = featureDims
-                .filter((v): v is number => typeof v === 'number')
-                .reduce((acc, val) => acc * val, 1);
-
-            if (totalInputFeatures > 0 && in_features !== totalInputFeatures) {
-                return {
-                    isValid: false,
-                    error: `Shape mismatch: input features ${totalInputFeatures} do not match layer's in_features ${in_features}`,
-                };
-            }
+        // nn.Linear applies to the LAST dimension only: (*, H_in) -> (*, H_out)
+        const orderedDims = getOrderedDimensions(inputShape);
+        if (orderedDims.length === 0) break;
+        const lastDim = inputShape[orderedDims[orderedDims.length - 1]];
+        if (typeof lastDim === "number" && lastDim !== in_features) {
+          return {
+            isValid: false,
+            error: `Shape mismatch: nn.Linear transforms the last dimension; the input's last dimension is ${lastDim} but the layer's in_features is ${in_features}. Add a Flatten node first if you want to collapse all dimensions.`,
+          };
         }
       }
       break;
@@ -596,10 +584,18 @@ export function calculateOutputShape(
       return inputShape;
     }
 
-    case "linearNode":
-      return {
-        features: nodeData.out_features || 64,
-      };
+    case "linearNode": {
+      // nn.Linear preserves all leading dimensions and replaces the last one:
+      // (*, H_in) -> (*, H_out)
+      const outFeatures = nodeData.out_features || 64;
+      const orderedDims = getOrderedDimensions(inputShape);
+      if (orderedDims.length === 0) {
+        return { features: outFeatures };
+      }
+      const newShape: TensorShape = { ...inputShape };
+      (newShape as any)[orderedDims[orderedDims.length - 1]] = outFeatures;
+      return newShape;
+    }
 
     case "timeDistributedLinearNode": {
       const shape = { ...inputShape };

--- a/tests/tensor-shape-calculator.test.ts
+++ b/tests/tensor-shape-calculator.test.ts
@@ -21,11 +21,31 @@ describe('validateTensorShapes', () => {
         expect(result.error).toMatch(/mismatch/i);
     });
 
-    it('flattens multi-dim input when validating linear in_features', () => {
+    it('validates linear in_features against the last dimension only (issue #5)', () => {
+        // Input [3, 30, 28] -> nn.Linear expects in_features=28, not 3*30*28
         const result = validateTensorShapes(
             'linearNode',
-            [{ channels: 16, height: 4, width: 4 }],
-            { in_features: 256, out_features: 10 },
+            [{ channels: 3, height: 30, width: 28 }],
+            { in_features: 28, out_features: 64 },
+        );
+        expect(result.isValid).toBe(true);
+    });
+
+    it('rejects linear in_features equal to the flattened product of a multi-dim input', () => {
+        const result = validateTensorShapes(
+            'linearNode',
+            [{ channels: 3, height: 30, width: 28 }],
+            { in_features: 2520, out_features: 64 },
+        );
+        expect(result.isValid).toBe(false);
+        expect(result.error).toMatch(/last dimension/i);
+    });
+
+    it('accepts a dynamic last dimension for linear layers', () => {
+        const result = validateTensorShapes(
+            'linearNode',
+            [{ sequence: 10, features: 'dynamic' }],
+            { in_features: 128, out_features: 64 },
         );
         expect(result.isValid).toBe(true);
     });
@@ -50,6 +70,30 @@ describe('validateTensorShapes', () => {
 });
 
 describe('calculateOutputShape', () => {
+    it('linear preserves leading dimensions and replaces the last one (issue #5)', () => {
+        // Input [3, 30, 28] -> Linear(28, 64) -> [3, 30, 64]
+        const out = calculateOutputShape(
+            'linearNode',
+            [{ channels: 3, height: 30, width: 28 }],
+            { in_features: 28, out_features: 64 },
+        );
+        expect(out).toEqual({ channels: 3, height: 30, width: 64 });
+    });
+
+    it('linear on a flat feature vector replaces features', () => {
+        const out = calculateOutputShape(
+            'linearNode',
+            [{ features: 784 }],
+            { in_features: 784, out_features: 128 },
+        );
+        expect(out).toEqual({ features: 128 });
+    });
+
+    it('linear with no input shape falls back to out_features', () => {
+        const out = calculateOutputShape('linearNode', [{}], { in_features: 10, out_features: 5 });
+        expect(out).toEqual({ features: 5 });
+    });
+
     it('preserves channels through MaxPool3d', () => {
         const out = calculateOutputShape(
             'maxpool3dNode',


### PR DESCRIPTION
## Summary

Fixes #5.

`nn.Linear` transforms **only the last dimension**: input `(*, H_in)` → output `(*, H_out)` ([PyTorch docs](https://docs.pytorch.org/docs/stable/generated/torch.nn.Linear.html)). The designer treated a linear layer as if it flattened its whole input, in three places:

- **`propagateTensorShapes` (app/page.tsx)** — auto-set `in_features` to the flattened product of all input dimensions. For the issue's `[3, 30, 28]` input it wrote `in_features=2520`, so the generated code crashed with the exact `mat1 and mat2 shapes cannot be multiplied` error in the report. It now tracks the input's **last** dimension (`28`).
- **`calculateOutputShape` (lib/tensor-shape-calculator.ts)** — collapsed the output to a single `features` dim. It now preserves leading dimensions: `[3, 30, 28]` → `Linear(28, 64)` → `[3, 30, 64]`, as the issue expects.
- **`validateTensorShapes`** — compared `in_features` against the product of all non-batch dims, so a *correct* `in_features=28` was flagged as a mismatch. It now validates against the last dimension and the error message suggests adding a Flatten node when the user actually wants to collapse dimensions.

Also migrates the examples API route to Next 15 async `params` (surfaced by the build-generated route types).

## Verification

- `vitest run`: 43/43 passing, including new tests reproducing the issue scenario (`[3, 30, 28]` + `in_features=28` valid → output `[3, 30, 64]`; `in_features=2520` rejected)
- `tsc --noEmit`: clean
- `next build`: succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013bvg5Q4aGGRXHsPkN32NHR

---
_Generated by [Claude Code](https://claude.ai/code/session_013bvg5Q4aGGRXHsPkN32NHR)_