### PR TITLE
Add PyTorch layer reference docs; add RMSNorm & GELU approximate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ This application provides a powerful drag-and-drop interface that allows users t
 
 -   **Visual Model Building:** Drag, drop, and connect nodes to build your network architecture.
 -   **Rich Layer Library:** A wide range of PyTorch layers are supported, including:
-    -   Core layers (Linear, Conv2D, Pooling, Dropout)
-    -   Activation functions (ReLU, Sigmoid, Tanh, etc.)
-    -   Normalization layers (BatchNorm, LayerNorm)
-    -   Advanced layers (LSTM, GRU, Transformers)
+    -   Core layers (Linear, Conv1D/2D/3D, Transposed Conv, Pooling, Dropout)
+    -   Activation functions (ReLU, LeakyReLU, GELU, SiLU, Mish, Hardswish, Softmax, etc.)
+    -   Normalization layers (BatchNorm, LayerNorm, **RMSNorm**, GroupNorm, InstanceNorm)
+    -   Advanced layers (LSTM, GRU, RNN, MultiheadAttention, Transformer encoder/decoder)
+-   **Up-to-date PyTorch API:** Layers are mapped to the current **PyTorch 2.x** `torch.nn` API, including recent additions such as `nn.RMSNorm` (PyTorch 2.4+) and the `approximate` option on `nn.GELU`. See the [PyTorch Layer Reference](docs/PYTORCH.md) for the full mapping and links to the official docs.
 -   **Real-time Shape Propagation:** Automatically calculates and displays the output tensor shape for each layer as you build.
 -   **Model Validation:** Checks for common errors such as shape mismatches, disconnected nodes, and cycles.
 -   **Code Generation:** Export your visual model to clean, readable PyTorch code.
@@ -25,6 +26,10 @@ This application provides a powerful drag-and-drop interface that allows users t
 -   **Save, Load, Import & Export:** Save models to your browser's local storage, or export/import them as `.json` files to share and back up your work.
 -   **Model Analysis:** Get insights into your model's complexity, including total parameters, FLOPs, and estimated memory usage.
 -   **Example Library:** Load and explore pre-built models like LeNet-5, ResNet, U-Net, and YOLO to learn common architectures.
+
+## Documentation
+
+-   **[PyTorch Layer Reference](docs/PYTORCH.md):** How each canvas layer maps onto the `torch.nn` API, which constructor arguments the code generator emits, version compatibility notes, and links to the official PyTorch documentation for every layer.
 
 ## Tech Stack
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -105,6 +105,7 @@ import { AdaptiveAvgPool2DNode } from "@/components/nodes/AdaptiveAvgPool2DNode"
 import { BatchNorm1DNode } from "@/components/nodes/BatchNorm1DNode"
 import { BatchNorm2DNode } from "@/components/nodes/BatchNorm2DNode"
 import { LayerNormNode } from "@/components/nodes/LayerNormNode"
+import { RMSNormNode } from "@/components/nodes/RMSNormNode"
 import { GroupNormNode } from "@/components/nodes/GroupNormNode"
 import { ConcatenateNode } from "@/components/nodes/ConcatenateNode"
 import { AddNode } from "@/components/nodes/AddNode"
@@ -255,6 +256,7 @@ const nodeTypes: NodeTypes = {
   batchnorm2dNode: BatchNorm2DNode,
   batchnorm3dNode: BatchNorm3DNode,
   layernormNode: LayerNormNode,
+  rmsnormNode: RMSNormNode,
   groupnormNode: GroupNormNode,
   instancenorm1dNode: InstanceNorm1DNode,
   instancenorm2dNode: InstanceNorm2DNode,
@@ -1284,6 +1286,7 @@ export default function NeuralNetworkDesigner() {
           BatchNorm2d: "batchnorm2dNode",
           BatchNorm3d: "batchnorm3dNode",
           LayerNorm: "layernormNode",
+          RMSNorm: "rmsnormNode",
           GroupNorm: "groupnormNode",
           InstanceNorm1d: "instancenorm1dNode",
           InstanceNorm2d: "instancenorm2dNode",
@@ -1605,6 +1608,7 @@ export default function NeuralNetworkDesigner() {
       case 'batchnorm1dNode':
       case 'batchnorm2dNode':
       case 'layernormNode':
+      case 'rmsnormNode':
       case 'groupnormNode':
       case 'instancenorm1dNode':
       case 'instancenorm2dNode':
@@ -2027,6 +2031,15 @@ export default function NeuralNetworkDesigner() {
                     <div className="flex items-center gap-2">
                       <BarChart3 className="h-4 w-4 text-cyan-500" />
                       <span className="text-sm font-medium text-sidebar-foreground">LayerNorm</span>
+                    </div>
+                  </Card>
+                  <Card
+                    className="p-3 cursor-pointer hover:bg-sidebar-accent/50 transition-colors border-sidebar-border"
+                    onClick={() => addNode("rmsnormNode", { normalized_shape: [128] })}
+                  >
+                    <div className="flex items-center gap-2">
+                      <BarChart3 className="h-4 w-4 text-cyan-500" />
+                      <span className="text-sm font-medium text-sidebar-foreground">RMSNorm</span>
                     </div>
                   </Card>
                   <Card
@@ -2974,6 +2987,47 @@ export default function NeuralNetworkDesigner() {
                         onUpdate={(value) => updateNodeData(selectedNode.id, { eps: value })}
                       />
                     </>
+                  )}
+                  {selectedNode.type === "rmsnormNode" && (
+                    <>
+                      <EditableNumberInput
+                        label="Normalized Shape"
+                        value={
+                          Array.isArray(selectedNode.data.normalized_shape)
+                            ? (selectedNode.data.normalized_shape[selectedNode.data.normalized_shape.length - 1] as number)
+                            : (selectedNode.data.normalized_shape as number | undefined)
+                        }
+                        defaultValue={128}
+                        min={1}
+                        onUpdate={(value) => updateNodeData(selectedNode.id, { normalized_shape: [value] })}
+                      />
+                      <EditableNumberInput
+                        label="Epsilon (eps)"
+                        value={selectedNode.data.eps as number | undefined}
+                        defaultValue={1e-5}
+                        min={0}
+                        step={1e-6}
+                        onUpdate={(value) => updateNodeData(selectedNode.id, { eps: value })}
+                      />
+                    </>
+                  )}
+                  {selectedNode.type === "geluNode" && (
+                    <div className="space-y-2">
+                      <label htmlFor="gelu-approximate" className="text-sm font-medium">Approximate</label>
+                      <select
+                        id="gelu-approximate"
+                        className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                        value={(selectedNode.data.approximate as string | undefined) ?? "none"}
+                        onChange={(e) =>
+                          updateNodeData(selectedNode.id, {
+                            approximate: e.target.value === "none" ? undefined : e.target.value,
+                          })
+                        }
+                      >
+                        <option value="none">none (exact)</option>
+                        <option value="tanh">tanh (approximation)</option>
+                      </select>
+                    </div>
                   )}
                   {selectedNode.type === "groupnormNode" && (
                     <>

--- a/components/designer/LayerPalette.tsx
+++ b/components/designer/LayerPalette.tsx
@@ -95,6 +95,7 @@ const LAYER_SECTIONS: LayerSection[] = [
             { type: 'batchnorm1dNode', label: 'BatchNorm1D', icon: <BarChart3 className="h-4 w-4 text-cyan-500" />, data: { num_features: 128 } },
             { type: 'batchnorm2dNode', label: 'BatchNorm2D', icon: <BarChart3 className="h-4 w-4 text-cyan-500" />, data: { num_features: 32 } },
             { type: 'layernormNode', label: 'LayerNorm', icon: <BarChart3 className="h-4 w-4 text-cyan-500" />, data: { normalized_shape: [128] } },
+            { type: 'rmsnormNode', label: 'RMSNorm', icon: <BarChart3 className="h-4 w-4 text-cyan-500" />, data: { normalized_shape: [128] } },
             { type: 'groupnormNode', label: 'GroupNorm', icon: <BarChart3 className="h-4 w-4 text-cyan-500" />, data: { num_groups: 8, num_channels: 32 } },
             { type: 'instancenorm1dNode', label: 'InstanceNorm1D', icon: <BarChart3 className="h-4 w-4 text-cyan-500" />, data: { num_features: 128 } },
             { type: 'instancenorm2dNode', label: 'InstanceNorm2D', icon: <BarChart3 className="h-4 w-4 text-cyan-500" />, data: { num_features: 32 } },

--- a/components/nodes/RMSNormNode.tsx
+++ b/components/nodes/RMSNormNode.tsx
@@ -1,0 +1,28 @@
+import { Handle, Position } from "@xyflow/react"
+import { Card } from "@/components/ui/card"
+import { Network } from "lucide-react"
+import { formatTensorShape } from "@/lib/tensor-shape-calculator"
+
+export function RMSNormNode({ data }: { data: any }) {
+  return (
+    <Card className="w-56 border-2 border-cyan-500/50 bg-card">
+      <Handle type="target" position={Position.Left} className="w-3 h-3 bg-cyan-500 border-2 border-background" />
+      <div className="p-3">
+        <div className="flex items-center gap-2 mb-2">
+          <Network className="h-4 w-4 text-cyan-500" />
+          <span className="font-medium text-sm">RMSNorm</span>
+        </div>
+        <div className="text-xs text-muted-foreground">
+          <div>Shape: {Array.isArray(data.normalized_shape) ? `[${data.normalized_shape.join(", ")}]` : data.normalized_shape}</div>
+        </div>
+        <div className="mt-2 pt-2 border-t border-border">
+          <div className="text-xs space-y-1">
+            <div className="text-green-600">In: {formatTensorShape(data.inputShape)}</div>
+            <div className="text-blue-600">Out: {formatTensorShape(data.outputShape)}</div>
+          </div>
+        </div>
+      </div>
+      <Handle type="source" position={Position.Right} className="w-3 h-3 bg-cyan-500 border-2 border-background" />
+    </Card>
+  )
+}

--- a/docs/PYTORCH.md
+++ b/docs/PYTORCH.md
@@ -1,0 +1,211 @@
+# PyTorch Layer Reference
+
+This document describes how the layers available in the **PyTorch Neural Network
+Designer** map onto the [`torch.nn`](https://docs.pytorch.org/docs/stable/nn.html)
+API, which constructor arguments the code generator emits, and where to find the
+authoritative PyTorch documentation for each one.
+
+It is the human-readable companion to the machine-readable
+[`PYTORCH_LAYER_MANIFEST`](../lib/types.ts), which is the single source of truth
+the code generator uses. When you add or change a layer there, update this file to
+match.
+
+## PyTorch version compatibility
+
+The generated code targets the **PyTorch 2.x** stable API. As of mid-2026 the
+current stable release is **PyTorch 2.11** (Python 3.10–3.14), and every module
+listed here is available in the `torch.nn` namespace. A few layers were added in
+recent releases:
+
+| Layer | Available since | Notes |
+| --- | --- | --- |
+| `nn.RMSNorm` | PyTorch **2.4** | Root-mean-square layer norm used by LLaMA, Gemma, and most modern LLMs. Requires PyTorch ≥ 2.4. |
+| `nn.GELU(approximate=...)` | PyTorch **1.12** | The `approximate` argument (`'none'` / `'tanh'`) selects the exact or tanh-approximated formulation. |
+| `nn.Mish`, `nn.Hardswish`, `nn.SiLU` | PyTorch ≥ 1.7 | Modern activations widely used in EfficientNet / MobileNetV3-style networks. |
+
+If you need to target an older PyTorch, avoid the layers noted above (in
+particular `nn.RMSNorm`, which will raise `AttributeError` on PyTorch < 2.4).
+
+## How code generation works
+
+Each node on the canvas has a `type` (for example `conv2dNode`). The generator
+looks the type up in `PYTORCH_LAYER_MANIFEST` to find:
+
+- **`className`** – the `torch.nn` class to instantiate (or `null` for nodes that
+  are handled inline in the `forward` pass, such as `Add` or `Concatenate`).
+- **`params`** – the constructor arguments to emit, **in order**. Only arguments
+  that are actually set on the node are written, so PyTorch defaults apply to the
+  rest.
+- **`doc`** – a link to the official documentation page for that layer.
+
+For example, a `linearNode` with `in_features=784`, `out_features=128` produces:
+
+```python
+self.layer = nn.Linear(in_features=784, out_features=128)
+```
+
+Values are converted to Python literals: booleans become `True`/`False`, arrays
+become tuples, and numeric strings are left unquoted.
+
+## Supported layers
+
+The tables below group every supported node by category. The **Node type** column
+is the internal identifier; the **PyTorch class** is what the generator emits.
+
+### Linear
+
+| Node type | PyTorch class | Parameters | Docs |
+| --- | --- | --- | --- |
+| `linearNode` | `nn.Linear` | `in_features`, `out_features`, `bias` | [Linear](https://docs.pytorch.org/docs/stable/generated/torch.nn.Linear.html) |
+
+### Convolution
+
+| Node type | PyTorch class | Parameters | Docs |
+| --- | --- | --- | --- |
+| `conv1dNode` | `nn.Conv1d` | `in_channels`, `out_channels`, `kernel_size`, `stride`, `padding`, `dilation`, `groups`, `bias` | [Conv1d](https://docs.pytorch.org/docs/stable/generated/torch.nn.Conv1d.html) |
+| `conv2dNode` | `nn.Conv2d` | `in_channels`, `out_channels`, `kernel_size`, `stride`, `padding`, `dilation`, `groups`, `bias` | [Conv2d](https://docs.pytorch.org/docs/stable/generated/torch.nn.Conv2d.html) |
+| `conv3dNode` | `nn.Conv3d` | `in_channels`, `out_channels`, `kernel_size`, `stride`, `padding`, `dilation`, `groups`, `bias` | [Conv3d](https://docs.pytorch.org/docs/stable/generated/torch.nn.Conv3d.html) |
+| `depthwiseconv2dNode` | `nn.Conv2d` (with `groups=in_channels`) | `in_channels`, `out_channels`, `kernel_size`, `stride`, `padding`, `dilation`, `bias` | [Conv2d](https://docs.pytorch.org/docs/stable/generated/torch.nn.Conv2d.html) |
+| `separableconv2dNode` | `nn.Sequential` (depthwise + pointwise `nn.Conv2d`) | `in_channels`, `out_channels`, `kernel_size`, `stride`, `padding` | [Conv2d](https://docs.pytorch.org/docs/stable/generated/torch.nn.Conv2d.html) |
+
+### Transposed convolution
+
+| Node type | PyTorch class | Parameters | Docs |
+| --- | --- | --- | --- |
+| `convtranspose1dNode` | `nn.ConvTranspose1d` | `in_channels`, `out_channels`, `kernel_size`, `stride`, `padding`, `output_padding`, `groups`, `bias`, `dilation` | [ConvTranspose1d](https://docs.pytorch.org/docs/stable/generated/torch.nn.ConvTranspose1d.html) |
+| `convtranspose2dNode` | `nn.ConvTranspose2d` | `in_channels`, `out_channels`, `kernel_size`, `stride`, `padding`, `output_padding`, `groups`, `bias`, `dilation` | [ConvTranspose2d](https://docs.pytorch.org/docs/stable/generated/torch.nn.ConvTranspose2d.html) |
+| `convtranspose3dNode` | `nn.ConvTranspose3d` | `in_channels`, `out_channels`, `kernel_size`, `stride`, `padding`, `output_padding`, `groups`, `bias`, `dilation` | [ConvTranspose3d](https://docs.pytorch.org/docs/stable/generated/torch.nn.ConvTranspose3d.html) |
+
+### Pooling
+
+| Node type | PyTorch class | Parameters | Docs |
+| --- | --- | --- | --- |
+| `maxpool1dNode` | `nn.MaxPool1d` | `kernel_size`, `stride`, `padding`, `dilation`, `return_indices`, `ceil_mode` | [MaxPool1d](https://docs.pytorch.org/docs/stable/generated/torch.nn.MaxPool1d.html) |
+| `maxpool2dNode` | `nn.MaxPool2d` | `kernel_size`, `stride`, `padding`, `dilation`, `return_indices`, `ceil_mode` | [MaxPool2d](https://docs.pytorch.org/docs/stable/generated/torch.nn.MaxPool2d.html) |
+| `maxpool3dNode` | `nn.MaxPool3d` | `kernel_size`, `stride`, `padding`, `dilation`, `return_indices`, `ceil_mode` | [MaxPool3d](https://docs.pytorch.org/docs/stable/generated/torch.nn.MaxPool3d.html) |
+| `avgpool1dNode` | `nn.AvgPool1d` | `kernel_size`, `stride`, `padding`, `ceil_mode`, `count_include_pad` | [AvgPool1d](https://docs.pytorch.org/docs/stable/generated/torch.nn.AvgPool1d.html) |
+| `avgpool2dNode` | `nn.AvgPool2d` | `kernel_size`, `stride`, `padding`, `ceil_mode`, `count_include_pad`, `divisor_override` | [AvgPool2d](https://docs.pytorch.org/docs/stable/generated/torch.nn.AvgPool2d.html) |
+| `avgpool3dNode` | `nn.AvgPool3d` | `kernel_size`, `stride`, `padding`, `ceil_mode`, `count_include_pad`, `divisor_override` | [AvgPool3d](https://docs.pytorch.org/docs/stable/generated/torch.nn.AvgPool3d.html) |
+| `adaptiveavgpool1dNode` | `nn.AdaptiveAvgPool1d` | `output_size` | [AdaptiveAvgPool1d](https://docs.pytorch.org/docs/stable/generated/torch.nn.AdaptiveAvgPool1d.html) |
+| `adaptiveavgpool2dNode` | `nn.AdaptiveAvgPool2d` | `output_size` | [AdaptiveAvgPool2d](https://docs.pytorch.org/docs/stable/generated/torch.nn.AdaptiveAvgPool2d.html) |
+| `adaptiveavgpool3dNode` | `nn.AdaptiveAvgPool3d` | `output_size` | [AdaptiveAvgPool3d](https://docs.pytorch.org/docs/stable/generated/torch.nn.AdaptiveAvgPool3d.html) |
+| `adaptivemaxpool1dNode` | `nn.AdaptiveMaxPool1d` | `output_size` | [AdaptiveMaxPool1d](https://docs.pytorch.org/docs/stable/generated/torch.nn.AdaptiveMaxPool1d.html) |
+| `adaptivemaxpool2dNode` | `nn.AdaptiveMaxPool2d` | `output_size` | [AdaptiveMaxPool2d](https://docs.pytorch.org/docs/stable/generated/torch.nn.AdaptiveMaxPool2d.html) |
+| `adaptivemaxpool3dNode` | `nn.AdaptiveMaxPool3d` | `output_size` | [AdaptiveMaxPool3d](https://docs.pytorch.org/docs/stable/generated/torch.nn.AdaptiveMaxPool3d.html) |
+| `lppool2dNode` | `nn.LPPool2d` | `norm_type`, `kernel_size`, `stride`, `ceil_mode` | [LPPool2d](https://docs.pytorch.org/docs/stable/generated/torch.nn.LPPool2d.html) |
+| `fractionalmaxpool2dNode` | `nn.FractionalMaxPool2d` | `kernel_size`, `output_size`, `output_ratio`, `return_indices` | [FractionalMaxPool2d](https://docs.pytorch.org/docs/stable/generated/torch.nn.FractionalMaxPool2d.html) |
+
+### Normalization
+
+| Node type | PyTorch class | Parameters | Docs |
+| --- | --- | --- | --- |
+| `batchnorm1dNode` | `nn.BatchNorm1d` | `num_features`, `eps`, `momentum`, `affine`, `track_running_stats` | [BatchNorm1d](https://docs.pytorch.org/docs/stable/generated/torch.nn.BatchNorm1d.html) |
+| `batchnorm2dNode` | `nn.BatchNorm2d` | `num_features`, `eps`, `momentum`, `affine`, `track_running_stats` | [BatchNorm2d](https://docs.pytorch.org/docs/stable/generated/torch.nn.BatchNorm2d.html) |
+| `batchnorm3dNode` | `nn.BatchNorm3d` | `num_features`, `eps`, `momentum`, `affine`, `track_running_stats` | [BatchNorm3d](https://docs.pytorch.org/docs/stable/generated/torch.nn.BatchNorm3d.html) |
+| `layernormNode` | `nn.LayerNorm` | `normalized_shape`, `eps`, `elementwise_affine` | [LayerNorm](https://docs.pytorch.org/docs/stable/generated/torch.nn.LayerNorm.html) |
+| `rmsnormNode` | `nn.RMSNorm` | `normalized_shape`, `eps`, `elementwise_affine` | [RMSNorm](https://docs.pytorch.org/docs/stable/generated/torch.nn.RMSNorm.html) |
+| `instancenorm1dNode` | `nn.InstanceNorm1d` | `num_features`, `eps`, `momentum`, `affine`, `track_running_stats` | [InstanceNorm1d](https://docs.pytorch.org/docs/stable/generated/torch.nn.InstanceNorm1d.html) |
+| `instancenorm2dNode` | `nn.InstanceNorm2d` | `num_features`, `eps`, `momentum`, `affine`, `track_running_stats` | [InstanceNorm2d](https://docs.pytorch.org/docs/stable/generated/torch.nn.InstanceNorm2d.html) |
+| `instancenorm3dNode` | `nn.InstanceNorm3d` | `num_features`, `eps`, `momentum`, `affine`, `track_running_stats` | [InstanceNorm3d](https://docs.pytorch.org/docs/stable/generated/torch.nn.InstanceNorm3d.html) |
+| `groupnormNode` | `nn.GroupNorm` | `num_groups`, `num_channels`, `eps`, `affine` | [GroupNorm](https://docs.pytorch.org/docs/stable/generated/torch.nn.GroupNorm.html) |
+
+> **RMSNorm vs. LayerNorm.** `nn.RMSNorm` normalizes by the root-mean-square of the
+> activations *without* subtracting the mean, and (with the default
+> `elementwise_affine=True`) has a single learnable scale and **no bias**. This
+> makes it cheaper than `nn.LayerNorm` and is the norm of choice in most modern
+> transformer LLMs.
+
+### Activation
+
+| Node type | PyTorch class | Parameters | Docs |
+| --- | --- | --- | --- |
+| `reluNode` | `nn.ReLU` | `inplace` | [ReLU](https://docs.pytorch.org/docs/stable/generated/torch.nn.ReLU.html) |
+| `leakyreluNode` | `nn.LeakyReLU` | `negative_slope`, `inplace` | [LeakyReLU](https://docs.pytorch.org/docs/stable/generated/torch.nn.LeakyReLU.html) |
+| `eluNode` | `nn.ELU` | `alpha`, `inplace` | [ELU](https://docs.pytorch.org/docs/stable/generated/torch.nn.ELU.html) |
+| `seluNode` | `nn.SELU` | `inplace` | [SELU](https://docs.pytorch.org/docs/stable/generated/torch.nn.SELU.html) |
+| `geluNode` | `nn.GELU` | `approximate` (`'none'` \| `'tanh'`) | [GELU](https://docs.pytorch.org/docs/stable/generated/torch.nn.GELU.html) |
+| `siluNode` | `nn.SiLU` | `inplace` | [SiLU](https://docs.pytorch.org/docs/stable/generated/torch.nn.SiLU.html) |
+| `mishNode` | `nn.Mish` | `inplace` | [Mish](https://docs.pytorch.org/docs/stable/generated/torch.nn.Mish.html) |
+| `hardswishNode` | `nn.Hardswish` | `inplace` | [Hardswish](https://docs.pytorch.org/docs/stable/generated/torch.nn.Hardswish.html) |
+| `hardsigmoidNode` | `nn.Hardsigmoid` | `inplace` | [Hardsigmoid](https://docs.pytorch.org/docs/stable/generated/torch.nn.Hardsigmoid.html) |
+| `sigmoidNode` | `nn.Sigmoid` | – | [Sigmoid](https://docs.pytorch.org/docs/stable/generated/torch.nn.Sigmoid.html) |
+| `tanhNode` | `nn.Tanh` | – | [Tanh](https://docs.pytorch.org/docs/stable/generated/torch.nn.Tanh.html) |
+| `softmaxNode` | `nn.Softmax` | `dim` | [Softmax](https://docs.pytorch.org/docs/stable/generated/torch.nn.Softmax.html) |
+| `logsoftmaxNode` | `nn.LogSoftmax` | `dim` | [LogSoftmax](https://docs.pytorch.org/docs/stable/generated/torch.nn.LogSoftmax.html) |
+
+> **GELU `approximate`.** The default `'none'` computes the exact GELU using the
+> Gaussian CDF. `'tanh'` uses the faster tanh approximation
+> `0.5 · x · (1 + tanh(√(2/π)·(x + 0.044715·x³)))`. The designer only emits the
+> argument when you change it away from the default.
+
+### Regularization
+
+| Node type | PyTorch class | Parameters | Docs |
+| --- | --- | --- | --- |
+| `dropoutNode` | `nn.Dropout` | `p`, `inplace` | [Dropout](https://docs.pytorch.org/docs/stable/generated/torch.nn.Dropout.html) |
+| `dropout2dNode` | `nn.Dropout2d` | `p`, `inplace` | [Dropout2d](https://docs.pytorch.org/docs/stable/generated/torch.nn.Dropout2d.html) |
+| `dropout3dNode` | `nn.Dropout3d` | `p`, `inplace` | [Dropout3d](https://docs.pytorch.org/docs/stable/generated/torch.nn.Dropout3d.html) |
+
+### Recurrent
+
+| Node type | PyTorch class | Parameters | Docs |
+| --- | --- | --- | --- |
+| `lstmNode` | `nn.LSTM` | `input_size`, `hidden_size`, `num_layers`, `bias`, `batch_first`, `dropout`, `bidirectional` | [LSTM](https://docs.pytorch.org/docs/stable/generated/torch.nn.LSTM.html) |
+| `gruNode` | `nn.GRU` | `input_size`, `hidden_size`, `num_layers`, `bias`, `batch_first`, `dropout`, `bidirectional` | [GRU](https://docs.pytorch.org/docs/stable/generated/torch.nn.GRU.html) |
+| `rnnNode` | `nn.RNN` | `input_size`, `hidden_size`, `num_layers`, `nonlinearity`, `bias`, `batch_first`, `dropout`, `bidirectional` | [RNN](https://docs.pytorch.org/docs/stable/generated/torch.nn.RNN.html) |
+
+> Recurrent modules return a `(output, hidden_state)` tuple; the generator unpacks
+> the first element (`output, _ = self.layer(x)`) so downstream nodes receive the
+> sequence output.
+
+### Attention & Transformers
+
+| Node type | PyTorch class | Parameters | Docs |
+| --- | --- | --- | --- |
+| `multiheadattentionNode` | `nn.MultiheadAttention` | `embed_dim`, `num_heads`, `dropout`, `bias`, `add_bias_kv`, `add_zero_attn`, `kdim`, `vdim` | [MultiheadAttention](https://docs.pytorch.org/docs/stable/generated/torch.nn.MultiheadAttention.html) |
+| `transformerencoderlayerNode` | `nn.TransformerEncoderLayer` | `d_model`, `nhead`, `dim_feedforward`, `dropout`, `activation`, `layer_norm_eps`, `batch_first`, `norm_first` | [TransformerEncoderLayer](https://docs.pytorch.org/docs/stable/generated/torch.nn.TransformerEncoderLayer.html) |
+| `transformerdecoderlayerNode` | `nn.TransformerDecoderLayer` | `d_model`, `nhead`, `dim_feedforward`, `dropout`, `activation`, `layer_norm_eps`, `batch_first`, `norm_first` | [TransformerDecoderLayer](https://docs.pytorch.org/docs/stable/generated/torch.nn.TransformerDecoderLayer.html) |
+
+> `nn.MultiheadAttention` takes `(query, key, value)` and returns
+> `(attn_output, attn_weights)`. With a single incoming edge the generator wires it
+> as self-attention (`q = k = v`) and keeps only `attn_output`. For the raw
+> attention primitive, see
+> [`torch.nn.functional.scaled_dot_product_attention`](https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html).
+
+### Shape / utility
+
+| Node type | PyTorch class | Parameters | Docs |
+| --- | --- | --- | --- |
+| `flattenNode` | `nn.Flatten` | `start_dim`, `end_dim` | [Flatten](https://docs.pytorch.org/docs/stable/generated/torch.nn.Flatten.html) |
+| `upsampleNode` | `nn.Upsample` | `size`, `scale_factor`, `mode`, `align_corners` | [Upsample](https://docs.pytorch.org/docs/stable/generated/torch.nn.Upsample.html) |
+| `reshapeNode` | `Tensor.view` (inline) | `targetShape` | [Tensor.view](https://docs.pytorch.org/docs/stable/generated/torch.Tensor.view.html) |
+| `transposeNode` | `torch.transpose` (inline) | `dim0`, `dim1` | [torch.transpose](https://docs.pytorch.org/docs/stable/generated/torch.transpose.html) |
+
+### Combining operations (handled inline in `forward`)
+
+These nodes do not create an `nn.Module`; they are emitted directly in the
+`forward` pass.
+
+| Node type | Emitted as | Parameters | Docs |
+| --- | --- | --- | --- |
+| `addNode` | `a + b` (elementwise, e.g. residual skip connection) | – | – |
+| `multiplyNode` | `a * b` (elementwise) | – | – |
+| `concatenateNode` | `torch.cat([...], dim=...)` | `dim` | [torch.cat](https://docs.pytorch.org/docs/stable/generated/torch.cat.html) |
+
+### Composite / block layers
+
+Higher-level building blocks composed from the primitives above. These are
+generated with dedicated logic rather than a single `nn` class.
+
+| Node type | Description |
+| --- | --- |
+| `mbconvNode` | Mobile inverted bottleneck (MBConv) block used in MobileNetV2/V3 and EfficientNet. |
+| `invertedResidualBlockNode` | Inverted residual block (MobileNetV2). |
+| `seBlockNode` / `seBottleneckNode` | Squeeze-and-Excitation channel-attention block / bottleneck. |
+| `ssmNode` | Selective state-space model (Mamba-style) block. |
+
+## Further reading
+
+- [`torch.nn` — full module index](https://docs.pytorch.org/docs/stable/nn.html)
+- [PyTorch documentation home](https://docs.pytorch.org/docs/stable/index.html)
+- [PyTorch release notes](https://github.com/pytorch/pytorch/releases)

--- a/lib/model-analyzer.ts
+++ b/lib/model-analyzer.ts
@@ -181,6 +181,15 @@ export function analyzeLayer(
       analysis.flops = batchSize * lnFeatures * 5 // mean, var, normalize, scale, shift
       break
 
+    case "rmsnormNode":
+      // RMSNorm has only a learnable scale (weight) when elementwise_affine=True,
+      // and no bias/mean subtraction (that is what distinguishes it from LayerNorm).
+      const rmsShape = nodeData.normalized_shape || [128]
+      const rmsFeatures = Array.isArray(rmsShape) ? rmsShape.reduce((a, b) => a * b, 1) : rmsShape
+      analysis.parameters = nodeData.elementwise_affine === false ? 0 : rmsFeatures // gamma only
+      analysis.flops = batchSize * rmsFeatures * 3 // square-mean, rsqrt-normalize, scale
+      break
+
     case "lstmNode":
     case "gruNode":
     case "rnnNode":

--- a/lib/tensor-shape-calculator.ts
+++ b/lib/tensor-shape-calculator.ts
@@ -949,6 +949,7 @@ export function calculateOutputShape(
     }
 
     case "layernormNode":
+    case "rmsnormNode":
       return inputShape;
 
     case "groupnormNode":

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -221,242 +221,324 @@ export interface GenerateModelResponse {
   error?: string
 }
 
-// PyTorch layer manifest - defines layer parameters and class names
-export const PYTORCH_LAYER_MANIFEST = {
+// Layer manifest entry describing how a canvas node maps onto a PyTorch module.
+// `className` is the `torch.nn` class emitted by the code generator (or `null`
+// for nodes handled specially / inline in the forward pass). `params` lists the
+// constructor arguments emitted in declaration order. `doc` links to the
+// matching page in the official PyTorch documentation (stable channel).
+export interface LayerManifestEntry {
+  className: string | null
+  params: string[]
+  doc: string | null
+}
+
+// Base URL for the stable PyTorch documentation. Individual layer pages follow
+// the `generated/torch.nn.<Class>.html` convention.
+export const PYTORCH_DOCS_BASE = "https://docs.pytorch.org/docs/stable"
+
+const nnDoc = (cls: string): string => `${PYTORCH_DOCS_BASE}/generated/torch.nn.${cls}.html`
+
+// PyTorch layer manifest - defines layer parameters, class names, and doc links.
+// Verified against the PyTorch 2.x `torch.nn` API (stable docs).
+export const PYTORCH_LAYER_MANIFEST: Record<string, LayerManifestEntry> = {
   linearNode: {
     className: "nn.Linear",
-    params: ["in_features", "out_features", "bias"]
+    params: ["in_features", "out_features", "bias"],
+    doc: nnDoc("Linear")
   },
   conv1dNode: {
     className: "nn.Conv1d",
-    params: ["in_channels", "out_channels", "kernel_size", "stride", "padding", "dilation", "groups", "bias"]
+    params: ["in_channels", "out_channels", "kernel_size", "stride", "padding", "dilation", "groups", "bias"],
+    doc: nnDoc("Conv1d")
   },
   conv2dNode: {
     className: "nn.Conv2d",
-    params: ["in_channels", "out_channels", "kernel_size", "stride", "padding", "dilation", "groups", "bias"]
+    params: ["in_channels", "out_channels", "kernel_size", "stride", "padding", "dilation", "groups", "bias"],
+    doc: nnDoc("Conv2d")
   },
   conv3dNode: {
     className: "nn.Conv3d",
-    params: ["in_channels", "out_channels", "kernel_size", "stride", "padding", "dilation", "groups", "bias"]
+    params: ["in_channels", "out_channels", "kernel_size", "stride", "padding", "dilation", "groups", "bias"],
+    doc: nnDoc("Conv3d")
   },
   maxpool1dNode: {
     className: "nn.MaxPool1d",
-    params: ["kernel_size", "stride", "padding", "dilation", "return_indices", "ceil_mode"]
+    params: ["kernel_size", "stride", "padding", "dilation", "return_indices", "ceil_mode"],
+    doc: nnDoc("MaxPool1d")
   },
   maxpool2dNode: {
     className: "nn.MaxPool2d",
-    params: ["kernel_size", "stride", "padding", "dilation", "return_indices", "ceil_mode"]
+    params: ["kernel_size", "stride", "padding", "dilation", "return_indices", "ceil_mode"],
+    doc: nnDoc("MaxPool2d")
   },
   maxpool3dNode: {
     className: "nn.MaxPool3d",
-    params: ["kernel_size", "stride", "padding", "dilation", "return_indices", "ceil_mode"]
+    params: ["kernel_size", "stride", "padding", "dilation", "return_indices", "ceil_mode"],
+    doc: nnDoc("MaxPool3d")
   },
   avgpool1dNode: {
     className: "nn.AvgPool1d",
-    params: ["kernel_size", "stride", "padding", "ceil_mode", "count_include_pad"]
+    params: ["kernel_size", "stride", "padding", "ceil_mode", "count_include_pad"],
+    doc: nnDoc("AvgPool1d")
   },
   avgpool2dNode: {
     className: "nn.AvgPool2d",
-    params: ["kernel_size", "stride", "padding", "ceil_mode", "count_include_pad", "divisor_override"]
+    params: ["kernel_size", "stride", "padding", "ceil_mode", "count_include_pad", "divisor_override"],
+    doc: nnDoc("AvgPool2d")
   },
   avgpool3dNode: {
     className: "nn.AvgPool3d",
-    params: ["kernel_size", "stride", "padding", "ceil_mode", "count_include_pad", "divisor_override"]
+    params: ["kernel_size", "stride", "padding", "ceil_mode", "count_include_pad", "divisor_override"],
+    doc: nnDoc("AvgPool3d")
   },
   adaptiveavgpool1dNode: {
     className: "nn.AdaptiveAvgPool1d",
-    params: ["output_size"]
+    params: ["output_size"],
+    doc: nnDoc("AdaptiveAvgPool1d")
   },
   adaptiveavgpool2dNode: {
     className: "nn.AdaptiveAvgPool2d",
-    params: ["output_size"]
+    params: ["output_size"],
+    doc: nnDoc("AdaptiveAvgPool2d")
   },
   adaptiveavgpool3dNode: {
     className: "nn.AdaptiveAvgPool3d",
-    params: ["output_size"]
+    params: ["output_size"],
+    doc: nnDoc("AdaptiveAvgPool3d")
   },
   adaptivemaxpool1dNode: {
     className: "nn.AdaptiveMaxPool1d",
-    params: ["output_size"]
+    params: ["output_size"],
+    doc: nnDoc("AdaptiveMaxPool1d")
   },
   adaptivemaxpool2dNode: {
     className: "nn.AdaptiveMaxPool2d",
-    params: ["output_size"]
+    params: ["output_size"],
+    doc: nnDoc("AdaptiveMaxPool2d")
   },
   adaptivemaxpool3dNode: {
     className: "nn.AdaptiveMaxPool3d",
-    params: ["output_size"]
+    params: ["output_size"],
+    doc: nnDoc("AdaptiveMaxPool3d")
   },
   lppool2dNode: {
     className: "nn.LPPool2d",
-    params: ["norm_type", "kernel_size", "stride", "ceil_mode"]
+    params: ["norm_type", "kernel_size", "stride", "ceil_mode"],
+    doc: nnDoc("LPPool2d")
   },
   fractionalmaxpool2dNode: {
     className: "nn.FractionalMaxPool2d",
-    params: ["kernel_size", "output_size", "output_ratio", "return_indices"]
+    params: ["kernel_size", "output_size", "output_ratio", "return_indices"],
+    doc: nnDoc("FractionalMaxPool2d")
   },
   batchnorm1dNode: {
     className: "nn.BatchNorm1d",
-    params: ["num_features", "eps", "momentum", "affine", "track_running_stats"]
+    params: ["num_features", "eps", "momentum", "affine", "track_running_stats"],
+    doc: nnDoc("BatchNorm1d")
   },
   batchnorm2dNode: {
     className: "nn.BatchNorm2d",
-    params: ["num_features", "eps", "momentum", "affine", "track_running_stats"]
+    params: ["num_features", "eps", "momentum", "affine", "track_running_stats"],
+    doc: nnDoc("BatchNorm2d")
   },
   batchnorm3dNode: {
     className: "nn.BatchNorm3d",
-    params: ["num_features", "eps", "momentum", "affine", "track_running_stats"]
+    params: ["num_features", "eps", "momentum", "affine", "track_running_stats"],
+    doc: nnDoc("BatchNorm3d")
   },
   layernormNode: {
     className: "nn.LayerNorm",
-    params: ["normalized_shape", "eps", "elementwise_affine"]
+    params: ["normalized_shape", "eps", "elementwise_affine"],
+    doc: nnDoc("LayerNorm")
+  },
+  rmsnormNode: {
+    className: "nn.RMSNorm",
+    params: ["normalized_shape", "eps", "elementwise_affine"],
+    doc: nnDoc("RMSNorm")
   },
   instancenorm1dNode: {
     className: "nn.InstanceNorm1d",
-    params: ["num_features", "eps", "momentum", "affine", "track_running_stats"]
+    params: ["num_features", "eps", "momentum", "affine", "track_running_stats"],
+    doc: nnDoc("InstanceNorm1d")
   },
   instancenorm2dNode: {
     className: "nn.InstanceNorm2d",
-    params: ["num_features", "eps", "momentum", "affine", "track_running_stats"]
+    params: ["num_features", "eps", "momentum", "affine", "track_running_stats"],
+    doc: nnDoc("InstanceNorm2d")
   },
   instancenorm3dNode: {
     className: "nn.InstanceNorm3d",
-    params: ["num_features", "eps", "momentum", "affine", "track_running_stats"]
+    params: ["num_features", "eps", "momentum", "affine", "track_running_stats"],
+    doc: nnDoc("InstanceNorm3d")
   },
   groupnormNode: {
     className: "nn.GroupNorm",
-    params: ["num_groups", "num_channels", "eps", "affine"]
+    params: ["num_groups", "num_channels", "eps", "affine"],
+    doc: nnDoc("GroupNorm")
   },
   reluNode: {
     className: "nn.ReLU",
-    params: ["inplace"]
+    params: ["inplace"],
+    doc: nnDoc("ReLU")
   },
   leakyreluNode: {
     className: "nn.LeakyReLU",
-    params: ["negative_slope", "inplace"]
+    params: ["negative_slope", "inplace"],
+    doc: nnDoc("LeakyReLU")
   },
   sigmoidNode: {
     className: "nn.Sigmoid",
-    params: []
+    params: [],
+    doc: nnDoc("Sigmoid")
   },
   tanhNode: {
     className: "nn.Tanh",
-    params: []
+    params: [],
+    doc: nnDoc("Tanh")
   },
   eluNode: {
     className: "nn.ELU",
-    params: ["alpha", "inplace"]
+    params: ["alpha", "inplace"],
+    doc: nnDoc("ELU")
   },
   seluNode: {
     className: "nn.SELU",
-    params: ["inplace"]
+    params: ["inplace"],
+    doc: nnDoc("SELU")
   },
   geluNode: {
     className: "nn.GELU",
-    params: []
+    params: ["approximate"],
+    doc: nnDoc("GELU")
   },
   siluNode: {
     className: "nn.SiLU",
-    params: ["inplace"]
+    params: ["inplace"],
+    doc: nnDoc("SiLU")
   },
   mishNode: {
     className: "nn.Mish",
-    params: ["inplace"]
+    params: ["inplace"],
+    doc: nnDoc("Mish")
   },
   hardswishNode: {
     className: "nn.Hardswish",
-    params: ["inplace"]
+    params: ["inplace"],
+    doc: nnDoc("Hardswish")
   },
   hardsigmoidNode: {
     className: "nn.Hardsigmoid",
-    params: ["inplace"]
+    params: ["inplace"],
+    doc: nnDoc("Hardsigmoid")
   },
   softmaxNode: {
     className: "nn.Softmax",
-    params: ["dim"]
+    params: ["dim"],
+    doc: nnDoc("Softmax")
   },
   logsoftmaxNode: {
     className: "nn.LogSoftmax",
-    params: ["dim"]
+    params: ["dim"],
+    doc: nnDoc("LogSoftmax")
   },
   dropoutNode: {
     className: "nn.Dropout",
-    params: ["p", "inplace"]
+    params: ["p", "inplace"],
+    doc: nnDoc("Dropout")
   },
   dropout2dNode: {
     className: "nn.Dropout2d",
-    params: ["p", "inplace"]
+    params: ["p", "inplace"],
+    doc: nnDoc("Dropout2d")
   },
   dropout3dNode: {
     className: "nn.Dropout3d",
-    params: ["p", "inplace"]
+    params: ["p", "inplace"],
+    doc: nnDoc("Dropout3d")
   },
   lstmNode: {
     className: "nn.LSTM",
-    params: ["input_size", "hidden_size", "num_layers", "bias", "batch_first", "dropout", "bidirectional"]
+    params: ["input_size", "hidden_size", "num_layers", "bias", "batch_first", "dropout", "bidirectional"],
+    doc: nnDoc("LSTM")
   },
   gruNode: {
     className: "nn.GRU",
-    params: ["input_size", "hidden_size", "num_layers", "bias", "batch_first", "dropout", "bidirectional"]
+    params: ["input_size", "hidden_size", "num_layers", "bias", "batch_first", "dropout", "bidirectional"],
+    doc: nnDoc("GRU")
   },
   rnnNode: {
     className: "nn.RNN",
-    params: ["input_size", "hidden_size", "num_layers", "nonlinearity", "bias", "batch_first", "dropout", "bidirectional"]
+    params: ["input_size", "hidden_size", "num_layers", "nonlinearity", "bias", "batch_first", "dropout", "bidirectional"],
+    doc: nnDoc("RNN")
   },
   multiheadattentionNode: {
     className: "nn.MultiheadAttention",
-    params: ["embed_dim", "num_heads", "dropout", "bias", "add_bias_kv", "add_zero_attn", "kdim", "vdim"]
+    params: ["embed_dim", "num_heads", "dropout", "bias", "add_bias_kv", "add_zero_attn", "kdim", "vdim"],
+    doc: nnDoc("MultiheadAttention")
   },
   transformerencoderlayerNode: {
     className: "nn.TransformerEncoderLayer",
-    params: ["d_model", "nhead", "dim_feedforward", "dropout", "activation", "layer_norm_eps", "batch_first", "norm_first"]
+    params: ["d_model", "nhead", "dim_feedforward", "dropout", "activation", "layer_norm_eps", "batch_first", "norm_first"],
+    doc: nnDoc("TransformerEncoderLayer")
   },
   transformerdecoderlayerNode: {
     className: "nn.TransformerDecoderLayer",
-    params: ["d_model", "nhead", "dim_feedforward", "dropout", "activation", "layer_norm_eps", "batch_first", "norm_first"]
+    params: ["d_model", "nhead", "dim_feedforward", "dropout", "activation", "layer_norm_eps", "batch_first", "norm_first"],
+    doc: nnDoc("TransformerDecoderLayer")
   },
   flattenNode: {
     className: "nn.Flatten",
-    params: ["start_dim", "end_dim"]
+    params: ["start_dim", "end_dim"],
+    doc: nnDoc("Flatten")
   },
   upsampleNode: {
     className: "nn.Upsample",
-    params: ["size", "scale_factor", "mode", "align_corners"]
+    params: ["size", "scale_factor", "mode", "align_corners"],
+    doc: nnDoc("Upsample")
   },
   convtranspose1dNode: {
     className: "nn.ConvTranspose1d",
-    params: ["in_channels", "out_channels", "kernel_size", "stride", "padding", "output_padding", "groups", "bias", "dilation"]
+    params: ["in_channels", "out_channels", "kernel_size", "stride", "padding", "output_padding", "groups", "bias", "dilation"],
+    doc: nnDoc("ConvTranspose1d")
   },
   convtranspose2dNode: {
     className: "nn.ConvTranspose2d",
-    params: ["in_channels", "out_channels", "kernel_size", "stride", "padding", "output_padding", "groups", "bias", "dilation"]
+    params: ["in_channels", "out_channels", "kernel_size", "stride", "padding", "output_padding", "groups", "bias", "dilation"],
+    doc: nnDoc("ConvTranspose2d")
   },
   convtranspose3dNode: {
     className: "nn.ConvTranspose3d",
-    params: ["in_channels", "out_channels", "kernel_size", "stride", "padding", "output_padding", "groups", "bias", "dilation"]
+    params: ["in_channels", "out_channels", "kernel_size", "stride", "padding", "output_padding", "groups", "bias", "dilation"],
+    doc: nnDoc("ConvTranspose3d")
   },
   depthwiseconv2dNode: {
     className: "nn.Conv2d",
-    params: ["in_channels", "out_channels", "kernel_size", "stride", "padding", "dilation", "bias"]
+    params: ["in_channels", "out_channels", "kernel_size", "stride", "padding", "dilation", "bias"],
+    doc: nnDoc("Conv2d")
   },
   separableconv2dNode: {
-    className: null, // Special handling in generator
-    params: ["in_channels", "out_channels", "kernel_size", "stride", "padding"]
+    className: null, // Special handling in generator (depthwise + pointwise Conv2d)
+    params: ["in_channels", "out_channels", "kernel_size", "stride", "padding"],
+    doc: nnDoc("Conv2d")
   },
   mbconvNode: {
     className: null, // Special handling in generator
-    params: ["in_channels", "out_channels", "kernel_size", "stride", "expand_ratio", "se_ratio"]
+    params: ["in_channels", "out_channels", "kernel_size", "stride", "expand_ratio", "se_ratio"],
+    doc: null
   },
   addNode: {
     className: null, // Special handling in generator
-    params: []
+    params: [],
+    doc: null
   },
   multiplyNode: {
     className: null, // Special handling in generator
-    params: []
+    params: [],
+    doc: null
   },
   concatenateNode: {
-    className: null, // Special handling in generator
-    params: ["dim"]
+    className: null, // Special handling in generator (torch.cat)
+    params: ["dim"],
+    doc: `${PYTORCH_DOCS_BASE}/generated/torch.cat.html`
   }
 }

--- a/tests/model-generator.test.ts
+++ b/tests/model-generator.test.ts
@@ -193,6 +193,39 @@ describe('ModelGenerator', () => {
         expect(code).toContain('const1 = torch.zeros(1, 1, 4, 4)');
     });
 
+    it('generates nn.RMSNorm with normalized_shape', () => {
+        const code = makeGraph(
+            [
+                inputNode('input1', { name: 'x', features: 128 }),
+                { id: 'norm', type: 'rmsnormNode', data: { normalized_shape: [128] } },
+            ],
+            [{ id: 'e1', source: 'input1', target: 'norm' }],
+        ).generateCode();
+
+        expect(code).toContain('self.norm = nn.RMSNorm(normalized_shape=(128))');
+        expect(code).toContain('norm = self.norm(x)');
+    });
+
+    it('omits the GELU approximate arg by default but emits it when set', () => {
+        const plain = makeGraph(
+            [
+                inputNode('input1', { name: 'x', features: 16 }),
+                { id: 'act', type: 'geluNode', data: {} },
+            ],
+            [{ id: 'e1', source: 'input1', target: 'act' }],
+        ).generateCode();
+        expect(plain).toContain('self.act = nn.GELU()');
+
+        const tanh = makeGraph(
+            [
+                inputNode('input1', { name: 'x', features: 16 }),
+                { id: 'act', type: 'geluNode', data: { approximate: 'tanh' } },
+            ],
+            [{ id: 'e1', source: 'input1', target: 'act' }],
+        ).generateCode();
+        expect(tanh).toContain('self.act = nn.GELU(approximate="tanh")');
+    });
+
     it('rejects graphs without an input node', () => {
         const generator = makeGraph(
             [{ id: 'fc1', type: 'linearNode', data: { in_features: 4, out_features: 2 } }],


### PR DESCRIPTION
## Summary

Researched the current **PyTorch 2.x** `torch.nn` API and brought the designer's documentation and layer support up to date. As of mid-2026 the current stable release is PyTorch 2.11 (Python 3.10–3.14); this PR aligns the app with that API surface, including layers added in recent releases.

## Documentation

- **New `docs/PYTORCH.md`** — a full reference mapping every canvas node to its `torch.nn` class, the constructor arguments the code generator emits, version-compatibility notes, and a link to the official PyTorch docs page for each layer.
- **`lib/types.ts`** — `PYTORCH_LAYER_MANIFEST` now carries an official documentation URL per layer and is backed by a typed `LayerManifestEntry` interface, so the program itself embeds accurate, current PyTorch documentation links.
- **`README.md`** — updated the layer list, added a PyTorch 2.x compatibility note, and linked the new reference doc.

## Program

- **`nn.RMSNorm` (`rmsnormNode`)** — added end to end: node component, Layer Palette entry, code-generation manifest, shape propagation (passthrough), parameter/FLOP estimation, PyTorch-code import mapping, and a property-panel editor. RMSNorm (added in PyTorch 2.4) is the normalization used by most modern LLMs and was previously missing.
- **`nn.GELU` `approximate` argument** — the manifest previously emitted no arguments for GELU, so the `approximate` (`'none'` / `'tanh'`) option could not be expressed. Added it to the manifest plus a property-panel selector; the argument is only emitted when changed from the default.

## Testing

- Added tests covering RMSNorm code generation and GELU `approximate` emission (default omitted, `'tanh'` emitted).
- Full suite green: **45 passed**.
- `pnpm build` compiles successfully; no new TypeScript errors introduced (the 5 pre-existing strict-mode errors in UI primitives are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VuGbbFzWtstEnRL5t7f8sB)_