### PR TITLE
Add Mixture-of-Experts (MoE) node and modern MoE example networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This application provides a powerful drag-and-drop interface that allows users t
     -   Activation functions (ReLU, LeakyReLU, GELU, SiLU, Mish, Hardswish, Softmax, etc.)
     -   Normalization layers (BatchNorm, LayerNorm, **RMSNorm**, GroupNorm, InstanceNorm)
     -   Advanced layers (LSTM, GRU, RNN, MultiheadAttention, Transformer encoder/decoder)
+    -   Modern LLM building blocks (**Mixture of Experts / sparse MoE FFN**, SSM/Mamba)
 -   **Up-to-date PyTorch API:** Layers are mapped to the current **PyTorch 2.x** `torch.nn` API, including recent additions such as `nn.RMSNorm` (PyTorch 2.4+) and the `approximate` option on `nn.GELU`. See the [PyTorch Layer Reference](docs/PYTORCH.md) for the full mapping and links to the official docs.
 -   **Real-time Shape Propagation:** Automatically calculates and displays the output tensor shape for each layer as you build.
 -   **Model Validation:** Checks for common errors such as shape mismatches, disconnected nodes, and cycles.
@@ -25,7 +26,7 @@ This application provides a powerful drag-and-drop interface that allows users t
 -   **Model Importer:** Paste existing PyTorch model code to visualize it on the canvas.
 -   **Save, Load, Import & Export:** Save models to your browser's local storage, or export/import them as `.json` files to share and back up your work.
 -   **Model Analysis:** Get insights into your model's complexity, including total parameters, FLOPs, and estimated memory usage.
--   **Example Library:** Load and explore pre-built models like LeNet-5, ResNet, U-Net, and YOLO to learn common architectures.
+-   **Example Library:** Load and explore pre-built models like LeNet-5, ResNet, U-Net, YOLO, and modern architectures such as the **MoE Transformer Block** (Mixtral / DeepSeek style) to learn common designs.
 
 ## Documentation
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -106,6 +106,7 @@ import { BatchNorm1DNode } from "@/components/nodes/BatchNorm1DNode"
 import { BatchNorm2DNode } from "@/components/nodes/BatchNorm2DNode"
 import { LayerNormNode } from "@/components/nodes/LayerNormNode"
 import { RMSNormNode } from "@/components/nodes/RMSNormNode"
+import { MoENode } from "@/components/nodes/MoENode"
 import { GroupNormNode } from "@/components/nodes/GroupNormNode"
 import { ConcatenateNode } from "@/components/nodes/ConcatenateNode"
 import { AddNode } from "@/components/nodes/AddNode"
@@ -257,6 +258,7 @@ const nodeTypes: NodeTypes = {
   batchnorm3dNode: BatchNorm3DNode,
   layernormNode: LayerNormNode,
   rmsnormNode: RMSNormNode,
+  moeNode: MoENode,
   groupnormNode: GroupNormNode,
   instancenorm1dNode: InstanceNorm1DNode,
   instancenorm2dNode: InstanceNorm2DNode,
@@ -1287,6 +1289,7 @@ export default function NeuralNetworkDesigner() {
           BatchNorm3d: "batchnorm3dNode",
           LayerNorm: "layernormNode",
           RMSNorm: "rmsnormNode",
+          MixtureOfExperts: "moeNode",
           GroupNorm: "groupnormNode",
           InstanceNorm1d: "instancenorm1dNode",
           InstanceNorm2d: "instancenorm2dNode",
@@ -1614,6 +1617,8 @@ export default function NeuralNetworkDesigner() {
       case 'instancenorm2dNode':
       case 'instancenorm3dNode':
         return '#06b6d4'; // cyan-500
+      case 'moeNode':
+        return '#d946ef'; // fuchsia-500
       case 'concatenateNode':
         return '#6366f1'; // indigo-500
       case 'addNode':
@@ -3028,6 +3033,52 @@ export default function NeuralNetworkDesigner() {
                         <option value="tanh">tanh (approximation)</option>
                       </select>
                     </div>
+                  )}
+                  {selectedNode.type === "moeNode" && (
+                    <>
+                      <EditableNumberInput
+                        label="d_model"
+                        value={selectedNode.data.d_model as number | undefined}
+                        defaultValue={512}
+                        min={1}
+                        onUpdate={(value) => updateNodeData(selectedNode.id, { d_model: value })}
+                        disabled={isInputConnected}
+                      />
+                      <EditableNumberInput
+                        label="Expert Hidden Dim (d_ff)"
+                        value={selectedNode.data.d_ff as number | undefined}
+                        defaultValue={2048}
+                        min={1}
+                        onUpdate={(value) => updateNodeData(selectedNode.id, { d_ff: value })}
+                      />
+                      <EditableNumberInput
+                        label="Number of Experts"
+                        value={selectedNode.data.num_experts as number | undefined}
+                        defaultValue={8}
+                        min={1}
+                        onUpdate={(value) => updateNodeData(selectedNode.id, { num_experts: value })}
+                      />
+                      <EditableNumberInput
+                        label="Top-K (experts / token)"
+                        value={selectedNode.data.top_k as number | undefined}
+                        defaultValue={2}
+                        min={1}
+                        onUpdate={(value) => updateNodeData(selectedNode.id, { top_k: value })}
+                      />
+                      <div className="space-y-2">
+                        <label htmlFor="moe-activation" className="text-sm font-medium">Expert Activation</label>
+                        <select
+                          id="moe-activation"
+                          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                          value={(selectedNode.data.activation as string | undefined) ?? "gelu"}
+                          onChange={(e) => updateNodeData(selectedNode.id, { activation: e.target.value })}
+                        >
+                          <option value="gelu">GELU</option>
+                          <option value="silu">SiLU (Swish)</option>
+                          <option value="relu">ReLU</option>
+                        </select>
+                      </div>
+                    </>
                   )}
                   {selectedNode.type === "groupnormNode" && (
                     <>

--- a/components/designer/LayerPalette.tsx
+++ b/components/designer/LayerPalette.tsx
@@ -18,6 +18,7 @@ import {
     Network,
     ArrowUpRight,
     ArrowDownLeft,
+    Boxes,
 } from 'lucide-react';
 
 interface LayerItem {
@@ -151,6 +152,12 @@ const LAYER_SECTIONS: LayerSection[] = [
         title: 'State Space Models',
         items: [
             { type: 'ssmNode', label: 'SSM/Mamba', icon: <Network className="h-4 w-4 text-purple-500" />, data: { d_model: 128, d_state: 16, expand_factor: 2 } },
+        ],
+    },
+    {
+        title: 'Mixture of Experts',
+        items: [
+            { type: 'moeNode', label: 'MoE (Sparse FFN)', icon: <Boxes className="h-4 w-4 text-fuchsia-500" />, data: { d_model: 512, d_ff: 2048, num_experts: 8, top_k: 2, activation: 'silu' } },
         ],
     },
     {

--- a/components/nodes/MoENode.tsx
+++ b/components/nodes/MoENode.tsx
@@ -1,0 +1,32 @@
+import { Handle, Position } from "@xyflow/react"
+import { Card } from "@/components/ui/card"
+import { Boxes } from "lucide-react"
+import { calculateOutputShape, formatTensorShape, type TensorShape } from "@/lib/tensor-shape-calculator"
+
+export function MoENode({ data }: { data: any }) {
+  const inputShape: TensorShape = data.inputShape
+  const outputShape = calculateOutputShape("moeNode", [inputShape], data)
+
+  return (
+    <Card className="min-w-[170px] border-2 border-fuchsia-500/50 bg-card">
+      <Handle type="target" position={Position.Left} className="w-3 h-3 bg-fuchsia-500 border-2 border-background" />
+      <div className="p-3">
+        <div className="flex items-center gap-2 mb-2">
+          <Boxes className="h-4 w-4 text-fuchsia-500" />
+          <span className="font-medium text-sm">MoE</span>
+        </div>
+        <div className="text-xs text-muted-foreground space-y-1">
+          <div>d_model: {data.d_model ?? "?"}</div>
+          <div>experts: {data.num_experts ?? "?"} (top-{data.top_k ?? 2})</div>
+        </div>
+        <div className="mt-2 pt-2 border-t border-border">
+          <div className="text-xs space-y-1">
+            <div className="text-green-600">In: {formatTensorShape(inputShape)}</div>
+            <div className="text-blue-600">Out: {formatTensorShape(outputShape)}</div>
+          </div>
+        </div>
+      </div>
+      <Handle type="source" position={Position.Right} className="w-3 h-3 bg-fuchsia-500 border-2 border-background" />
+    </Card>
+  )
+}

--- a/docs/PYTORCH.md
+++ b/docs/PYTORCH.md
@@ -203,8 +203,36 @@ generated with dedicated logic rather than a single `nn` class.
 | `invertedResidualBlockNode` | Inverted residual block (MobileNetV2). |
 | `seBlockNode` / `seBottleneckNode` | Squeeze-and-Excitation channel-attention block / bottleneck. |
 | `ssmNode` | Selective state-space model (Mamba-style) block. |
+| `moeNode` | Sparse **Mixture-of-Experts** feed-forward block (see below). |
+
+### Mixture of Experts (`moeNode`)
+
+A sparse Mixture-of-Experts (MoE) feed-forward block, the defining component of
+state-of-the-art open-weight LLMs (Mixtral, DeepSeek-V3/V4, Llama 4). It replaces
+a dense FFN with `num_experts` expert MLPs and a lightweight learned **gate** that
+routes each token to its **top-k** experts; the selected experts' outputs are
+combined by the renormalized softmax gate weights. Because only `top_k` experts
+run per token, total parameters scale far beyond the active compute per token.
+
+| Parameter | Meaning | Default |
+| --- | --- | --- |
+| `d_model` | Token / model dimension (input == output) | 512 |
+| `d_ff` | Hidden dimension of each expert MLP | 2048 |
+| `num_experts` | Total number of experts | 8 |
+| `top_k` | Experts activated per token | 2 |
+| `activation` | Expert activation: `gelu` \| `silu` \| `relu` | `gelu` |
+
+The code generator emits a self-contained, runnable `MixtureOfExperts(nn.Module)`
+helper class (implementing the gate, `torch.topk` routing, and weighted
+recombination) once per model, then instantiates it. It is shape-preserving:
+`(..., d_model)` in, `(..., d_model)` out. See the **Mixture of Experts (MoE)
+Layer** and **MoE Transformer Block** examples in the app.
 
 ## Further reading
+
+- [Mixtral of Experts (Jiang et al., 2024)](https://arxiv.org/abs/2401.04088)
+- [DeepSeek-V3 Technical Report](https://arxiv.org/abs/2412.19437)
+- [`torch.topk` — top-k selection used by the MoE router](https://docs.pytorch.org/docs/stable/generated/torch.topk.html)
 
 - [`torch.nn` — full module index](https://docs.pytorch.org/docs/stable/nn.html)
 - [PyTorch documentation home](https://docs.pytorch.org/docs/stable/index.html)

--- a/lib/example-networks.ts
+++ b/lib/example-networks.ts
@@ -21,6 +21,8 @@ export const EXAMPLE_NETWORKS_METADATA: ExampleNetworkMetadata[] = [
   { name: "BERT", filename: "BERT.json" },
   { name: "GPT2", filename: "GPT2.json" },
   { name: "Mamba", filename: "Mamba.json" },
+  { name: "Mixture of Experts (MoE) Layer", filename: "MoE-Layer.json" },
+  { name: "MoE Transformer Block", filename: "MoE-Transformer-Block.json" },
   { name: "SENet Block", filename: "SENet_Block.json" },
   { name: "U-Net", filename: "U-Net.json" },
   { name: "YOLOv1", filename: "YOLOv1.json" },

--- a/lib/examples/MoE-Layer.json
+++ b/lib/examples/MoE-Layer.json
@@ -1,0 +1,56 @@
+{
+    "name": "Mixture of Experts (MoE) Layer",
+    "description": "A standalone sparse Mixture-of-Experts feed-forward layer as used in modern LLMs (Mixtral, DeepSeek-V3, Llama 4). A learned gate routes each token to its top-2 of 8 expert MLPs; the selected experts' outputs are combined by the renormalized softmax gate weights. Only top_k experts run per token, so capacity scales without proportional compute.",
+    "nodes": [
+        {
+            "id": "input-1",
+            "type": "inputNode",
+            "position": {
+                "x": 100,
+                "y": 300
+            },
+            "data": {
+                "sequence": 128,
+                "features": 512
+            }
+        },
+        {
+            "id": "moe-1",
+            "type": "moeNode",
+            "position": {
+                "x": 420,
+                "y": 300
+            },
+            "data": {
+                "d_model": 512,
+                "d_ff": 2048,
+                "num_experts": 8,
+                "top_k": 2,
+                "activation": "silu"
+            }
+        },
+        {
+            "id": "output-1",
+            "type": "outputNode",
+            "position": {
+                "x": 720,
+                "y": 300
+            },
+            "data": {
+                "label": "Output"
+            }
+        }
+    ],
+    "edges": [
+        {
+            "id": "e-input-moe",
+            "source": "input-1",
+            "target": "moe-1"
+        },
+        {
+            "id": "e-moe-output",
+            "source": "moe-1",
+            "target": "output-1"
+        }
+    ]
+}

--- a/lib/examples/MoE-Transformer-Block.json
+++ b/lib/examples/MoE-Transformer-Block.json
@@ -1,0 +1,166 @@
+{
+    "name": "MoE Transformer Block",
+    "description": "A modern sparse Mixture-of-Experts transformer decoder block in the Mixtral / DeepSeek-V3 style. Uses pre-normalization with RMSNorm, multi-head self-attention with a residual connection, and a sparse MoE feed-forward network (top-2 of 8 experts) replacing the dense FFN, with a second residual connection. This is the core building block of state-of-the-art open-weight LLMs.",
+    "nodes": [
+        {
+            "id": "input-1",
+            "type": "inputNode",
+            "position": {
+                "x": -150,
+                "y": 400
+            },
+            "data": {
+                "sequence": 128,
+                "features": 512
+            }
+        },
+        {
+            "id": "rmsnorm-1",
+            "type": "rmsnormNode",
+            "position": {
+                "x": 150,
+                "y": 250
+            },
+            "data": {
+                "normalized_shape": [
+                    512
+                ]
+            }
+        },
+        {
+            "id": "mha-1",
+            "type": "multiheadattentionNode",
+            "position": {
+                "x": 420,
+                "y": 250
+            },
+            "data": {
+                "embed_dim": 512,
+                "num_heads": 8,
+                "dropout": 0.0,
+                "batch_first": true
+            }
+        },
+        {
+            "id": "add-1",
+            "type": "addNode",
+            "position": {
+                "x": 720,
+                "y": 400
+            },
+            "data": {}
+        },
+        {
+            "id": "rmsnorm-2",
+            "type": "rmsnormNode",
+            "position": {
+                "x": 960,
+                "y": 250
+            },
+            "data": {
+                "normalized_shape": [
+                    512
+                ]
+            }
+        },
+        {
+            "id": "moe-1",
+            "type": "moeNode",
+            "position": {
+                "x": 1220,
+                "y": 250
+            },
+            "data": {
+                "d_model": 512,
+                "d_ff": 2048,
+                "num_experts": 8,
+                "top_k": 2,
+                "activation": "silu"
+            }
+        },
+        {
+            "id": "add-2",
+            "type": "addNode",
+            "position": {
+                "x": 1520,
+                "y": 400
+            },
+            "data": {}
+        },
+        {
+            "id": "output-1",
+            "type": "outputNode",
+            "position": {
+                "x": 1780,
+                "y": 400
+            },
+            "data": {
+                "label": "Output"
+            }
+        }
+    ],
+    "edges": [
+        {
+            "id": "e-input-rms1",
+            "source": "input-1",
+            "target": "rmsnorm-1"
+        },
+        {
+            "id": "e-rms1-mha-q",
+            "source": "rmsnorm-1",
+            "target": "mha-1",
+            "targetHandle": "query"
+        },
+        {
+            "id": "e-rms1-mha-k",
+            "source": "rmsnorm-1",
+            "target": "mha-1",
+            "targetHandle": "key"
+        },
+        {
+            "id": "e-rms1-mha-v",
+            "source": "rmsnorm-1",
+            "target": "mha-1",
+            "targetHandle": "value"
+        },
+        {
+            "id": "e-input-add1",
+            "source": "input-1",
+            "target": "add-1",
+            "targetHandle": "input1"
+        },
+        {
+            "id": "e-mha-add1",
+            "source": "mha-1",
+            "target": "add-1",
+            "targetHandle": "input2"
+        },
+        {
+            "id": "e-add1-rms2",
+            "source": "add-1",
+            "target": "rmsnorm-2"
+        },
+        {
+            "id": "e-rms2-moe",
+            "source": "rmsnorm-2",
+            "target": "moe-1"
+        },
+        {
+            "id": "e-add1-add2",
+            "source": "add-1",
+            "target": "add-2",
+            "targetHandle": "input1"
+        },
+        {
+            "id": "e-moe-add2",
+            "source": "moe-1",
+            "target": "add-2",
+            "targetHandle": "input2"
+        },
+        {
+            "id": "e-add2-output",
+            "source": "add-2",
+            "target": "output-1"
+        }
+    ]
+}

--- a/lib/model-analyzer.ts
+++ b/lib/model-analyzer.ts
@@ -190,6 +190,22 @@ export function analyzeLayer(
       analysis.flops = batchSize * rmsFeatures * 3 // square-mean, rsqrt-normalize, scale
       break
 
+    case "moeNode": {
+      // Sparse MoE: all experts hold parameters, but only top_k run per token.
+      const dModel = nodeData.d_model || 512
+      const dFf = nodeData.d_ff || dModel * 4
+      const numExperts = nodeData.num_experts || 8
+      const topK = nodeData.top_k || 2
+      const expertParams = 2 * dModel * dFf + dFf + dModel // two linears (+biases)
+      const gateParams = dModel * numExperts // router (no bias)
+      analysis.parameters = numExperts * expertParams + gateParams
+      // Only the selected top_k experts execute per token -> active FLOPs.
+      const seqLen = typeof inputShape.sequence === "number" ? inputShape.sequence : 1
+      const activeParams = topK * expertParams + gateParams
+      analysis.flops = batchSize * seqLen * activeParams * 2
+      break
+    }
+
     case "lstmNode":
     case "gruNode":
     case "rnnNode":

--- a/lib/model-generator.ts
+++ b/lib/model-generator.ts
@@ -10,10 +10,60 @@ const FUNCTIONAL_NODE_TYPES = new Set([
   "transposeNode",
 ]);
 
+// Maps the MoE node's activation string to the torch.nn class used inside experts.
+const MOE_ACTIVATIONS: Record<string, string> = {
+  gelu: "nn.GELU",
+  silu: "nn.SiLU",
+  relu: "nn.ReLU",
+};
+
+// Reusable helper module emitted once when a graph contains a Mixture-of-Experts
+// node. Implements token-level top-k routing (Mixtral / DeepSeek style): a linear
+// gate scores every expert, the top-k are selected and renormalized, and each
+// token is processed only by its selected experts before a weighted recombination.
+const MOE_HELPER_CLASS = `class MixtureOfExperts(nn.Module):
+    """Sparse Mixture-of-Experts feed-forward block with top-k token routing.
+
+    Each token is routed to \`top_k\` of \`num_experts\` expert MLPs by a learned
+    gating network; the selected experts' outputs are combined with the
+    (renormalized) softmax gate weights. Shape-preserving: (..., d_model) in and out.
+    """
+
+    def __init__(self, d_model, d_ff, num_experts, top_k=2, activation=nn.GELU):
+        super().__init__()
+        self.num_experts = num_experts
+        self.top_k = top_k
+        self.gate = nn.Linear(d_model, num_experts, bias=False)
+        self.experts = nn.ModuleList([
+            nn.Sequential(
+                nn.Linear(d_model, d_ff),
+                activation(),
+                nn.Linear(d_ff, d_model),
+            )
+            for _ in range(num_experts)
+        ])
+
+    def forward(self, x):
+        input_shape = x.shape
+        x = x.reshape(-1, input_shape[-1])                      # (tokens, d_model)
+        routing_weights = torch.softmax(self.gate(x), dim=-1)   # (tokens, num_experts)
+        topk_weights, topk_idx = torch.topk(routing_weights, self.top_k, dim=-1)
+        topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
+
+        out = torch.zeros_like(x)
+        for e in range(self.num_experts):
+            token_idx, slot_idx = torch.where(topk_idx == e)
+            if token_idx.numel() == 0:
+                continue
+            weight = topk_weights[token_idx, slot_idx].unsqueeze(-1)
+            out[token_idx] += weight * self.experts[e](x[token_idx])
+        return out.reshape(input_shape)`;
+
 export class ModelGenerator {
   private readonly nodes: GraphNode[];
   private readonly edges: GraphEdge[];
   private readonly inputNodes: GraphNode[] = [];
+  private usesMoE = false;
 
   constructor(graph: GraphIR) {
     this.nodes = graph.nodes;
@@ -144,6 +194,19 @@ export class ModelGenerator {
             const shape = Array.isArray((node.data as any).shape) ? (node.data as any).shape : [1];
             initLines.push(`        self.${layerName} = nn.Parameter(torch.randn(${shape.join(", ")}))`);
             definedLayers.add(node.id);
+        } else if (node.type === "moeNode") {
+            const d = node.data as any;
+            const dModel = d.d_model ?? 512;
+            const dFf = d.d_ff ?? dModel * 4;
+            const numExperts = d.num_experts ?? 8;
+            const topK = d.top_k ?? 2;
+            const activation = MOE_ACTIVATIONS[String(d.activation ?? "gelu").toLowerCase()] ?? "nn.GELU";
+            initLines.push(
+                `        self.${layerName} = MixtureOfExperts(d_model=${dModel}, d_ff=${dFf}, ` +
+                `num_experts=${numExperts}, top_k=${topK}, activation=${activation})`
+            );
+            definedLayers.add(node.id);
+            this.usesMoE = true;
         } else if (!FUNCTIONAL_NODE_TYPES.has(node.type) && node.type !== "constantNode") {
             console.warn(`Node type ${node.type} does not have a manifest entry and is not a recognized functional node.`);
         }
@@ -171,6 +234,12 @@ export class ModelGenerator {
         const lastNode = sortedNodes[sortedNodes.length - 1];
         const lastVar = nodeOutputs.get(lastNode.id) ?? this.sanitizeArgName(lastNode.id);
         classDefinition += `\n        return ${lastVar}`;
+    }
+
+    // Emit reusable helper modules (e.g. MixtureOfExperts) between the imports
+    // and the generated model class, so the generated file is self-contained.
+    if (this.usesMoE) {
+      code += `\n\n${MOE_HELPER_CLASS}\n`;
     }
 
     code += classDefinition;

--- a/lib/tensor-shape-calculator.ts
+++ b/lib/tensor-shape-calculator.ts
@@ -952,6 +952,10 @@ export function calculateOutputShape(
     case "rmsnormNode":
       return inputShape;
 
+    // Mixture-of-Experts FFN preserves the token/model dimension
+    case "moeNode":
+      return inputShape;
+
     case "groupnormNode":
       return inputShape;
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -135,6 +135,15 @@ export interface MBConvNodeData extends BaseNodeData {
   se_ratio?: number;
 }
 
+// Mixture-of-Experts (sparse MoE feed-forward) node data
+export interface MoENodeData extends BaseNodeData {
+  d_model: number;      // token / model dimension (in == out)
+  d_ff: number;         // hidden dimension of each expert FFN
+  num_experts: number;  // total number of experts
+  top_k: number;        // experts activated per token
+  activation?: string;  // "gelu" | "silu" | "relu"
+}
+
 // Union type for all node data
 export type NodeData = 
   | InputNodeData
@@ -149,6 +158,7 @@ export type NodeData =
   | TransformerNodeData
   | OperationNodeData
   | MBConvNodeData
+  | MoENodeData
 
 // Network state for undo/redo
 export interface NetworkState {
@@ -525,6 +535,13 @@ export const PYTORCH_LAYER_MANIFEST: Record<string, LayerManifestEntry> = {
     className: null, // Special handling in generator
     params: ["in_channels", "out_channels", "kernel_size", "stride", "expand_ratio", "se_ratio"],
     doc: null
+  },
+  moeNode: {
+    // Special handling in generator: emits a reusable MixtureOfExperts helper class.
+    // Sparse Mixture-of-Experts feed-forward block (Mixtral / DeepSeek style).
+    className: null,
+    params: ["d_model", "d_ff", "num_experts", "top_k", "activation"],
+    doc: "https://docs.pytorch.org/docs/stable/generated/torch.topk.html"
   },
   addNode: {
     className: null, // Special handling in generator

--- a/tests/model-generator.test.ts
+++ b/tests/model-generator.test.ts
@@ -193,6 +193,41 @@ describe('ModelGenerator', () => {
         expect(code).toContain('const1 = torch.zeros(1, 1, 4, 4)');
     });
 
+    it('generates a Mixture-of-Experts block with a reusable helper class', () => {
+        const code = makeGraph(
+            [
+                inputNode('input1', { name: 'x', features: 512 }),
+                { id: 'moe', type: 'moeNode', data: { d_model: 512, d_ff: 2048, num_experts: 8, top_k: 2, activation: 'silu' } },
+            ],
+            [{ id: 'e1', source: 'input1', target: 'moe' }],
+        ).generateCode();
+
+        // Helper class is emitted once, before the model, and the layer is instantiated + called
+        expect(code).toContain('class MixtureOfExperts(nn.Module):');
+        expect(code).toContain('self.moe = MixtureOfExperts(d_model=512, d_ff=2048, num_experts=8, top_k=2, activation=nn.SiLU)');
+        expect(code).toContain('moe = self.moe(x)');
+        // Helper appears before the generated model class
+        expect(code.indexOf('class MixtureOfExperts')).toBeLessThan(code.indexOf('class GeneratedModel'));
+    });
+
+    it('emits the MoE helper class only once for multiple MoE nodes and maps activation', () => {
+        const code = makeGraph(
+            [
+                inputNode('input1', { name: 'x', features: 64 }),
+                { id: 'moe1', type: 'moeNode', data: { d_model: 64, d_ff: 128, num_experts: 4, top_k: 1, activation: 'gelu' } },
+                { id: 'moe2', type: 'moeNode', data: { d_model: 64, d_ff: 128, num_experts: 4, top_k: 2 } },
+            ],
+            [
+                { id: 'e1', source: 'input1', target: 'moe1' },
+                { id: 'e2', source: 'moe1', target: 'moe2' },
+            ],
+        ).generateCode();
+
+        expect(code.match(/class MixtureOfExperts\(nn\.Module\):/g)?.length).toBe(1);
+        expect(code).toContain('activation=nn.GELU'); // explicit gelu
+        expect(code).toContain('activation=nn.GELU)'); // default when unspecified also falls back to GELU
+    });
+
     it('generates nn.RMSNorm with normalized_shape', () => {
         const code = makeGraph(
             [


### PR DESCRIPTION
## Summary

Researched the current state of the art in ML and added the one dominant architecture that was missing from the example set: the **sparse Mixture of Experts (MoE)**. MoE is the defining design of 2025–2026 frontier open-weight LLMs — Mixtral, DeepSeek-V3/V4, and Llama 4 — and now powers the majority of serious open-weight releases. Representing it faithfully required a dedicated node, so this PR adds one.

## New node type: `moeNode` (sparse MoE feed-forward)

- Configurable **`d_model`**, **`d_ff`** (expert hidden dim), **`num_experts`**, **`top_k`** (experts per token), and expert **`activation`** (GELU / SiLU / ReLU).
- The code generator emits a **self-contained, runnable `MixtureOfExperts(nn.Module)` helper class** — learned gate → `torch.topk` token routing → renormalized softmax weighting → per-expert compute → weighted recombination — emitted **once** per model regardless of how many MoE nodes are present. Shape-preserving: `(…, d_model)` in and out.
- Full UI wiring: node component, a new **Mixture of Experts** section in the Layer Palette, node color, property-panel editor, and PyTorch-code **import mapping** (`MixtureOfExperts` → `moeNode`).
- Shape propagation (passthrough) and parameter / active-FLOP estimation in the model analyzer (accounts for only `top_k` experts running per token).

### Example generated code

```python
class MixtureOfExperts(nn.Module):
    def __init__(self, d_model, d_ff, num_experts, top_k=2, activation=nn.GELU):
        ...
        self.gate = nn.Linear(d_model, num_experts, bias=False)
        self.experts = nn.ModuleList([...])
    def forward(self, x):
        ...  # top-k routing + weighted recombination

class GeneratedModel(nn.Module):
    def __init__(self):
        super().__init__()
        self.moe = MixtureOfExperts(d_model=512, d_ff=2048, num_experts=8, top_k=2, activation=nn.SiLU)
```

## New example networks

- **Mixture of Experts (MoE) Layer** — a standalone sparse MoE FFN (top-2 of 8 experts).
- **MoE Transformer Block** — a Mixtral / DeepSeek-style **pre-norm decoder block**: RMSNorm → multi-head self-attention → residual, then RMSNorm → MoE FFN → residual. Combines the `nn.RMSNorm` layer added earlier with the new MoE node.

Both were round-tripped through the generator to confirm they produce clean, syntactically valid PyTorch.

## Documentation & tests

- **`docs/PYTORCH.md`** — new *Mixture of Experts* section (parameters, semantics, and references to the Mixtral and DeepSeek-V3 papers). **README** updated with the new block and example.
- Added generator tests: MoE code emission, single helper-class emission across multiple MoE nodes, and activation-string mapping.
- **47 tests pass**; `pnpm build` compiles successfully; no new TypeScript errors (the 5 pre-existing strict-mode errors in UI primitives are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VuGbbFzWtstEnRL5t7f8sB)_