### PR TITLE
UX/perf + features: dark mode, memoization, training codegen, shape diagnostics, share URLs, summary export

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,18 +14,20 @@ This application provides a powerful drag-and-drop interface that allows users t
 
 -   **Visual Model Building:** Drag, drop, and connect nodes to build your network architecture.
 -   **Rich Layer Library:** A wide range of PyTorch layers are supported, including:
-    -   Core layers (Linear, Conv1D/2D/3D, Transposed Conv, Pooling, Dropout)
+    -   Core layers (Linear, Embedding, Conv1D/2D/3D, Transposed Conv, Pooling, Dropout)
     -   Activation functions (ReLU, LeakyReLU, GELU, SiLU, Mish, Hardswish, Softmax, etc.)
     -   Normalization layers (BatchNorm, LayerNorm, **RMSNorm**, GroupNorm, InstanceNorm)
     -   Advanced layers (LSTM, GRU, RNN, MultiheadAttention, Transformer encoder/decoder)
     -   Modern LLM building blocks (**Mixture of Experts / sparse MoE FFN**, SSM/Mamba)
 -   **Up-to-date PyTorch API:** Layers are mapped to the current **PyTorch 2.x** `torch.nn` API, including recent additions such as `nn.RMSNorm` (PyTorch 2.4+) and the `approximate` option on `nn.GELU`. See the [PyTorch Layer Reference](docs/PYTORCH.md) for the full mapping and links to the official docs.
 -   **Real-time Shape Propagation:** Automatically calculates and displays the output tensor shape for each layer as you build.
--   **Model Validation:** Checks for common errors such as shape mismatches, disconnected nodes, and cycles.
--   **Code Generation:** Export your visual model to clean, readable PyTorch code.
+-   **Model Validation with actionable diagnostics:** Checks for common errors such as shape mismatches, disconnected nodes, and cycles — and reports *expected vs. actual* values with a concrete fix (e.g. "Linear expects `in_features=768` but receives a tensor whose last dimension is 393216 — insert a Flatten, set `in_features=393216`, or select a single token").
+-   **Code Generation:** Export your visual model to clean, readable PyTorch code — optionally including a runnable **training loop** (device, optimizer, loss, and a `DataLoader` scaffold) so you can go from diagram to something you can actually train.
 -   **Model Importer (full-graph reconstruction):** Paste existing PyTorch model code and the importer parses the `forward()` method to rebuild the *complete* computation graph — residual/skip connections, concatenations, branches, element-wise merges, functional activations (`F.relu`, `torch.cat`, …) and recursively **inlined submodules** (e.g. a ResNet's `BasicBlock`) — instead of a naive top-to-bottom list of layers.
 -   **Save, Load, Import & Export:** Save models to your browser's local storage, or export/import them as `.json` files to share and back up your work.
--   **Model Analysis:** Get insights into your model's complexity, including total parameters, FLOPs, and estimated memory usage.
+-   **Shareable Links:** Encode an entire model into a URL and share it — opening the link reconstructs the graph on the canvas (fully client-side, no backend).
+-   **Model Analysis & Summary Export:** Get insights into your model's complexity — total parameters, FLOPs, and estimated memory usage — and copy a `torchinfo`-style per-layer summary table as Markdown.
+-   **Dark Mode:** A built-in light/dark theme toggle.
 -   **Example Library:** Load and explore pre-built models like LeNet-5, ResNet, U-Net, YOLO, and modern architectures such as the **MoE Transformer Block** (Mixtral / DeepSeek style) to learn common designs.
 
 ## Documentation

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { GeistSans } from 'geist/font/sans'
 import { GeistMono } from 'geist/font/mono'
 import { Analytics } from '@vercel/analytics/next'
+import { ThemeProvider } from '@/components/theme-provider'
 import './globals.css'
 
 export const metadata: Metadata = {
@@ -16,9 +17,16 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body className={`font-sans ${GeistSans.variable} ${GeistMono.variable}`}>
-        {children}
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="light"
+          enableSystem
+          disableTransitionOnChange
+        >
+          {children}
+        </ThemeProvider>
         <Analytics />
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -61,6 +61,7 @@ import {
   FileUp,
   ArrowUpRight,
   ArrowDownLeft,
+  Share2,
 } from "lucide-react"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { ResizableBox } from "react-resizable"
@@ -79,7 +80,11 @@ import { useModelValidation } from "@/lib/model-validator"
 import { useUndoRedo } from "@/lib/undo-redo"
 import { useKeyboardShortcuts } from "@/lib/keyboard-shortcuts"
 import { parsePyTorchModel } from "@/lib/pytorch-parser"
+import { ModelGenerator, type TrainingOptions } from "@/lib/model-generator"
+import { buildShareUrl, readGraphFromHash } from "@/lib/share"
+import { formatModelSummary } from "@/lib/model-summary"
 import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
 import { EditableNumberInput } from "@/components/ui/EditableNumberInput"
 import { ThemeToggle } from "@/components/theme-toggle"
 import { ErrorBoundary } from "@/components/ErrorBoundary"
@@ -339,6 +344,10 @@ export default function NeuralNetworkDesigner() {
   const [showCodeDialog, setShowCodeDialog] = useState(false)
   const [generatedCode, setGeneratedCode] = useState("")
   const [isGenerating, setIsGenerating] = useState(false)
+  // Optional training-loop scaffold controls for the Generate Code dialog.
+  const [includeTraining, setIncludeTraining] = useState(false)
+  const [trainingOptimizer, setTrainingOptimizer] = useState<TrainingOptions["optimizer"]>("adam")
+  const [trainingLoss, setTrainingLoss] = useState<TrainingOptions["loss"]>("crossentropy")
   const { toast } = useToast()
   const isUpdatingShapes = useRef(false)
   const [copySuccess, setCopySuccess] = useState(false)
@@ -398,6 +407,27 @@ export default function NeuralNetworkDesigner() {
   }, [nodes, edges])
 
   useEffect(() => {
+    // A model shared via URL hash (#model=...) takes precedence over any
+    // auto-saved session. Uses the same load path as import/load: seed the
+    // graph + undo history, clear selection, fit the view.
+    if (typeof window !== "undefined") {
+      const sharedGraph = readGraphFromHash(window.location.hash)
+      if (sharedGraph && Array.isArray(sharedGraph.nodes) && sharedGraph.nodes.length > 0) {
+        resetHistory(sharedGraph.nodes as Node[], sharedGraph.edges as Edge[])
+        setSelectedNode(null)
+        toast({
+          title: "Loaded shared model",
+          description: "A model shared via link has been loaded onto the canvas.",
+        })
+        // Drop the hash so a refresh doesn't reload the shared model over edits.
+        window.history.replaceState(null, "", window.location.pathname + window.location.search)
+        setTimeout(() => {
+          reactFlowInstanceRef.current?.fitView({ padding: 0.1, duration: 800 })
+        }, 100)
+        return
+      }
+    }
+
     if (autoSave.hasSavedData()) {
       const loadedState = autoSave.load()
       if (loadedState) {
@@ -1056,52 +1086,104 @@ export default function NeuralNetworkDesigner() {
     })
   }, [generatedCode, toast])
 
+  // Shared clipboard helper with a secure (navigator.clipboard) path and an
+  // execCommand fallback for insecure contexts. `onSuccess` runs after a
+  // successful copy; failures surface a generic "Copy Failed" toast. All
+  // window/navigator/document access lives inside this handler (SSR-safe).
+  const copyTextToClipboard = useCallback(
+    (text: string, onSuccess: () => void) => {
+      const notifyFailure = () => {
+        toast({
+          title: "Copy Failed",
+          description: "Failed to copy to clipboard",
+          variant: "destructive",
+        })
+      }
+
+      const unsecuredCopyToClipboard = (value: string) => {
+        const textArea = document.createElement("textarea")
+        textArea.value = value
+        document.body.appendChild(textArea)
+        textArea.focus()
+        textArea.select()
+        try {
+          document.execCommand("copy")
+          onSuccess()
+        } catch {
+          notifyFailure()
+        }
+        document.body.removeChild(textArea)
+      }
+
+      if (window.isSecureContext && navigator.clipboard) {
+        navigator.clipboard.writeText(text).then(onSuccess).catch(notifyFailure)
+      } else {
+        unsecuredCopyToClipboard(text)
+      }
+    },
+    [toast],
+  )
+
   const copyCode = useCallback(() => {
     if (!generatedCode) return
+    copyTextToClipboard(generatedCode, () => {
+      setCopySuccess(true)
+      toast({
+        title: "Code Copied",
+        description: "Generated code copied to clipboard",
+      })
+      setTimeout(() => setCopySuccess(false), 2000)
+    })
+  }, [generatedCode, copyTextToClipboard, toast])
 
-    const unsecuredCopyToClipboard = (text: string) => {
-        const textArea = document.createElement("textarea");
-        textArea.value = text;
-        document.body.appendChild(textArea);
-        textArea.focus();
-        textArea.select();
-        try {
-            document.execCommand('copy');
-            setCopySuccess(true);
-            toast({
-                title: "Code Copied",
-                description: "Generated code copied to clipboard",
-            });
-            setTimeout(() => setCopySuccess(false), 2000);
-        } catch (err) {
-            toast({
-                title: "Copy Failed",
-                description: "Failed to copy code to clipboard",
-                variant: "destructive",
-            });
-        }
-        document.body.removeChild(textArea);
-    };
+  // Build a shareable URL that packs the current graph into the URL hash, and
+  // copy it to the clipboard using the shared helper. SSR-safe: `window` is
+  // only read inside this click handler.
+  const handleShare = useCallback(() => {
+    const url = buildShareUrl(window.location.origin + window.location.pathname, { nodes, edges })
+    copyTextToClipboard(url, () => {
+      toast({
+        title: "Share link copied",
+        description:
+          url.length > 2000
+            ? "The link is long because of the model size; some apps may truncate it."
+            : "Paste the link anywhere to share this model.",
+      })
+    })
+  }, [nodes, edges, copyTextToClipboard, toast])
 
-    if (window.isSecureContext && navigator.clipboard) {
-        navigator.clipboard.writeText(generatedCode).then(() => {
-            setCopySuccess(true);
-            toast({
-                title: "Code Copied",
-                description: "Generated code copied to clipboard",
-            });
-            setTimeout(() => setCopySuccess(false), 2000);
-        }).catch(() => {
-            toast({
-                title: "Copy Failed",
-                description: "Failed to copy code to clipboard",
-                variant: "destructive",
-            });
-        });
-    } else {
-        unsecuredCopyToClipboard(generatedCode);
+  // Copy the already-computed model analysis as a torchinfo-style markdown table.
+  const copyModelSummary = useCallback(() => {
+    if (!modelAnalysis) return
+    const summary = formatModelSummary(modelAnalysis, { format: "markdown" })
+    copyTextToClipboard(summary, () => {
+      toast({
+        title: "Summary copied",
+        description: "Model summary copied to clipboard as markdown.",
+      })
+    })
+  }, [modelAnalysis, copyTextToClipboard, toast])
+
+  // While the Code dialog is open, keep the shown code in sync with the training
+  // options: generate WITHOUT training by default, or WITH the training scaffold
+  // when the toggle is on. Regenerated client-side via ModelGenerator so option
+  // changes take effect immediately.
+  useEffect(() => {
+    if (!showCodeDialog) return
+    try {
+      const generator = new ModelGenerator({ nodes, edges } as any)
+      const code = includeTraining
+        ? generator.generateCode({ training: { optimizer: trainingOptimizer, loss: trainingLoss } })
+        : generator.generateCode()
+      setGeneratedCode(code)
+    } catch (error) {
+      toast({
+        title: "Generation Failed",
+        description: error instanceof Error ? error.message : "Failed to generate model code",
+        variant: "destructive",
+      })
     }
-}, [generatedCode, toast]);
+  }, [showCodeDialog, includeTraining, trainingOptimizer, trainingLoss, nodes, edges, toast])
 
   // --- Clipboard (copy/paste/cut) for canvas nodes ---
   const clipboardRef = useRef<{ nodes: Node[]; edges: Edge[] } | null>(null)
@@ -1400,6 +1482,10 @@ export default function NeuralNetworkDesigner() {
           <Button variant="outline" size="sm" onClick={handleOpenLoadDialog}>
             <FolderOpen className="h-4 w-4 mr-2" />
             Open
+          </Button>
+          <Button variant="outline" size="sm" onClick={handleShare}>
+            <Share2 className="h-4 w-4 mr-2" />
+            Share
           </Button>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
@@ -3238,6 +3324,47 @@ export default function NeuralNetworkDesigner() {
               Here is the PyTorch code for your model. You can copy it or download it as a Python file.
             </DialogDescription>
           </DialogHeader>
+          <div className="flex flex-wrap items-center gap-4 rounded-md border p-3 text-sm">
+            <label className="flex cursor-pointer items-center gap-2">
+              <input
+                type="checkbox"
+                checked={includeTraining}
+                onChange={(e) => setIncludeTraining(e.target.checked)}
+                className="h-4 w-4 accent-primary"
+              />
+              <span className="font-medium">Include training loop</span>
+            </label>
+            {includeTraining && (
+              <>
+                <div className="flex items-center gap-2">
+                  <Label htmlFor="training-optimizer">Optimizer</Label>
+                  <select
+                    id="training-optimizer"
+                    value={trainingOptimizer}
+                    onChange={(e) => setTrainingOptimizer(e.target.value as TrainingOptions["optimizer"])}
+                    className="h-8 rounded-md border border-input bg-background px-2 text-sm"
+                  >
+                    <option value="adam">Adam</option>
+                    <option value="adamw">AdamW</option>
+                    <option value="sgd">SGD</option>
+                  </select>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Label htmlFor="training-loss">Loss</Label>
+                  <select
+                    id="training-loss"
+                    value={trainingLoss}
+                    onChange={(e) => setTrainingLoss(e.target.value as TrainingOptions["loss"])}
+                    className="h-8 rounded-md border border-input bg-background px-2 text-sm"
+                  >
+                    <option value="crossentropy">CrossEntropy</option>
+                    <option value="mse">MSE</option>
+                    <option value="bce">BCE</option>
+                  </select>
+                </div>
+              </>
+            )}
+          </div>
           <div className="flex-1 relative my-4 min-h-0">
             <ScrollArea className="h-full rounded-md border">
               <pre className="p-4 font-mono text-sm whitespace-pre-wrap">{generatedCode}</pre>
@@ -3395,7 +3522,11 @@ export default function NeuralNetworkDesigner() {
               </div>
             </div>
           )}
-          <div className="flex justify-end pt-4 border-t">
+          <div className="flex justify-end gap-2 pt-4 border-t">
+            <Button variant="secondary" onClick={copyModelSummary} disabled={!modelAnalysis}>
+              <Copy className="h-3.5 w-3.5 mr-1.5" />
+              Copy summary
+            </Button>
             <Button variant="default" onClick={() => setShowAnalysisPanel(false)}>
               Close
             </Button>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -81,6 +81,8 @@ import { useKeyboardShortcuts } from "@/lib/keyboard-shortcuts"
 import { parsePyTorchModel } from "@/lib/pytorch-parser"
 import { Input } from "@/components/ui/input"
 import { EditableNumberInput } from "@/components/ui/EditableNumberInput"
+import { ThemeToggle } from "@/components/theme-toggle"
+import { ErrorBoundary } from "@/components/ErrorBoundary"
 
 // Custom Node Components
 import { InputNode } from "@/components/nodes/InputNode"
@@ -1386,6 +1388,7 @@ export default function NeuralNetworkDesigner() {
           )}
         </div>
         <div className="flex items-center gap-2">
+          <ThemeToggle />
           <Button variant="outline" size="sm" onClick={() => setShowHelpDialog(true)}>
             <HelpCircle className="h-4 w-4 mr-2" />
             Help
@@ -2023,6 +2026,7 @@ export default function NeuralNetworkDesigner() {
 
         {/* Main Canvas Area */}
         <div className="flex-1 h-full w-full" ref={reactFlowWrapper}>
+          <ErrorBoundary>
           <ReactFlowProvider>
             <ReactFlow
               nodes={nodes}
@@ -2048,6 +2052,7 @@ export default function NeuralNetworkDesigner() {
               <Background variant={BackgroundVariant.Dots} gap={20} size={1} />
             </ReactFlow>
           </ReactFlowProvider>
+          </ErrorBoundary>
         </div>
 
         {/* Right Panel: Properties & Live Validation */}
@@ -2670,7 +2675,7 @@ export default function NeuralNetworkDesigner() {
                           onChange={(e) =>
                             updateNodeData(selectedNode.id, { dim: parseInt(e.target.value, 10) })
                           }
-                          className="w-full px-2 py-1 text-sm border rounded focus:outline-none focus:ring-1 focus:ring-blue-500 bg-white text-black"
+                          className="w-full px-2 py-1 text-sm border rounded focus:outline-none focus:ring-1 focus:ring-blue-500 bg-background text-foreground"
                         >
                           <option value={1}>1</option>
                           <option value={2}>2</option>
@@ -3155,7 +3160,7 @@ export default function NeuralNetworkDesigner() {
                           onChange={(e) =>
                             updateNodeData(selectedNode.id, { downsample: e.target.value === 'true' })
                           }
-                          className="w-full px-2 py-1 text-sm border rounded focus:outline-none focus:ring-1 focus:ring-blue-500 bg-white text-black"
+                          className="w-full px-2 py-1 text-sm border rounded focus:outline-none focus:ring-1 focus:ring-blue-500 bg-background text-foreground"
                         >
                           <option value="true">Yes</option>
                           <option value="false">No</option>
@@ -3226,7 +3231,7 @@ export default function NeuralNetworkDesigner() {
 
       {/* Code Generation Dialog */}
       <Dialog open={showCodeDialog} onOpenChange={setShowCodeDialog}>
-        <DialogContent className="w-[65vw] h-[80vh] flex flex-col bg-gray-200 text-gray-900">
+        <DialogContent className="w-[65vw] h-[80vh] flex flex-col bg-background text-foreground">
           <DialogHeader>
             <DialogTitle>Generated PyTorch Code</DialogTitle>
             <DialogDescription>
@@ -3272,7 +3277,7 @@ export default function NeuralNetworkDesigner() {
       </Dialog>
 
       <Dialog open={showAnalysisPanel} onOpenChange={setShowAnalysisPanel}>
-        <DialogContent className="max-w-4xl max-h-[90vh] w-[65vw] bg-gray-200 text-gray-900">
+        <DialogContent className="max-w-4xl max-h-[90vh] w-[65vw] bg-background text-foreground">
           <DialogHeader>
             <DialogTitle>Model Analysis</DialogTitle>
           </DialogHeader>
@@ -3315,28 +3320,28 @@ export default function NeuralNetworkDesigner() {
                       {modelAnalysis.layers.map((layer, index) => (
                         <div
                           key={index}
-                          className="flex items-center justify-between p-3 bg-gray-50 rounded-lg min-w-0"
+                          className="flex items-center justify-between p-3 bg-muted rounded-lg min-w-0"
                         >
                           <div className="flex-1 min-w-0 mr-4">
                             <div className="font-medium text-sm truncate">{layer.name}</div>
-                            <div className="text-xs text-gray-600 truncate">{layer.type}</div>
+                            <div className="text-xs text-muted-foreground truncate">{layer.type}</div>
                           </div>
                           <div className="flex gap-4 text-xs flex-shrink-0">
                             <div className="text-center min-w-0">
-                              <div className="font-medium break-words text-gray-900">
+                              <div className="font-medium break-words text-foreground">
                                 {formatNumber(layer.parameters)}
                               </div>
-                              <div className="text-gray-600">Params</div>
+                              <div className="text-muted-foreground">Params</div>
                             </div>
                             <div className="text-center min-w-0">
-                              <div className="font-medium break-words text-gray-900">{formatNumber(layer.flops)}</div>
-                              <div className="text-gray-600">FLOPs</div>
+                              <div className="font-medium break-words text-foreground">{formatNumber(layer.flops)}</div>
+                              <div className="text-muted-foreground">FLOPs</div>
                             </div>
                             <div className="text-center min-w-0">
-                              <div className="font-medium break-words text-gray-900">
+                              <div className="font-medium break-words text-foreground">
                                 {layer.memoryMB.toFixed(1)} MB
                               </div>
-                              <div className="text-gray-600">Memory</div>
+                              <div className="text-muted-foreground">Memory</div>
                             </div>
                           </div>
                         </div>
@@ -3399,7 +3404,7 @@ export default function NeuralNetworkDesigner() {
       </Dialog>
 
       <Dialog open={showValidationPanel} onOpenChange={setShowValidationPanel}>
-        <DialogContent className="w-[65vw] h-[80vh] flex flex-col bg-gray-200 text-gray-900">
+        <DialogContent className="w-[65vw] h-[80vh] flex flex-col bg-background text-foreground">
           <DialogHeader>
             <DialogTitle>Model Validation Results</DialogTitle>
           </DialogHeader>
@@ -3435,7 +3440,7 @@ export default function NeuralNetworkDesigner() {
               ) : (
                 <div className="flex flex-col items-center justify-center h-full">
                   <p className="text-lg font-semibold">No issues found.</p>
-                  <p className="text-sm text-gray-700">Your model is looking good!</p>
+                  <p className="text-sm text-muted-foreground">Your model is looking good!</p>
                 </div>
               )}
             </ScrollArea>
@@ -3449,7 +3454,7 @@ export default function NeuralNetworkDesigner() {
       </Dialog>
 
       <Dialog open={showSaveDialog} onOpenChange={setShowSaveDialog}>
-        <DialogContent className="w-[50vw] bg-gray-200 text-gray-900">
+        <DialogContent className="w-[50vw] bg-background text-foreground">
           <DialogHeader>
             <DialogTitle>Save Model</DialogTitle>
             <DialogDescription>
@@ -3462,7 +3467,7 @@ export default function NeuralNetworkDesigner() {
               value={modelName}
               onChange={(e) => setModelName(e.target.value)}
               placeholder="My-CNN-Model"
-              className="bg-white text-black"
+              className="bg-background text-foreground"
             />
           </div>
           <DialogFooter>
@@ -3478,7 +3483,7 @@ export default function NeuralNetworkDesigner() {
       </Dialog>
 
       <Dialog open={showLoadDialog} onOpenChange={setShowLoadDialog}>
-        <DialogContent className="w-[50vw] bg-gray-200 text-gray-900">
+        <DialogContent className="w-[50vw] bg-background text-foreground">
           <DialogHeader>
             <DialogTitle>Open Model</DialogTitle>
             <DialogDescription>
@@ -3492,11 +3497,11 @@ export default function NeuralNetworkDesigner() {
                   savedModels.map((model) => (
                     <div
                       key={model.key}
-                      className="flex items-center justify-between rounded-lg border p-3 transition-all hover:bg-gray-100"
+                      className="flex items-center justify-between rounded-lg border p-3 transition-all hover:bg-muted"
                     >
                       <div>
                         <div className="font-semibold">{model.name}</div>
-                        <div className="text-xs text-gray-600">Saved: {new Date(model.timestamp).toLocaleString()}</div>
+                        <div className="text-xs text-muted-foreground">Saved: {new Date(model.timestamp).toLocaleString()}</div>
                       </div>
                       <div className="flex gap-2">
                         <Button size="sm" onClick={() => handleLoadModel(model.key)}>
@@ -3509,7 +3514,7 @@ export default function NeuralNetworkDesigner() {
                     </div>
                   ))
                 ) : (
-                  <div className="text-center text-gray-500 py-10">No saved models found.</div>
+                  <div className="text-center text-muted-foreground py-10">No saved models found.</div>
                 )}
               </div>
             </ScrollArea>
@@ -3533,7 +3538,7 @@ export default function NeuralNetworkDesigner() {
       </Dialog>
 
       <Dialog open={showCodeInputDialog} onOpenChange={setShowCodeInputDialog}>
-        <DialogContent className="w-[80vw] h-[80vh] flex flex-col bg-gray-200 text-gray-900">
+        <DialogContent className="w-[80vw] h-[80vh] flex flex-col bg-background text-foreground">
           <DialogHeader>
             <DialogTitle>Input PyTorch Code</DialogTitle>
             <DialogDescription>
@@ -3620,7 +3625,7 @@ class MyModel(nn.Module):
       </Dialog>
 
       <Dialog open={showHelpDialog} onOpenChange={setShowHelpDialog}>
-        <DialogContent className="max-w-4xl max-h-[90vh] w-[65vw] bg-gray-200 text-gray-900">
+        <DialogContent className="max-w-4xl max-h-[90vh] w-[65vw] bg-background text-foreground">
           <DialogHeader>
             <DialogTitle>Neural Network Designer - Help Guide</DialogTitle>
           </DialogHeader>
@@ -3629,7 +3634,7 @@ class MyModel(nn.Module):
               {/* Getting Started */}
               <div className="space-y-3">
                 <h3 className="text-lg font-semibold">🚀 Getting Started</h3>
-                <div className="space-y-2 text-sm text-gray-700">
+                <div className="space-y-2 text-sm text-muted-foreground">
                   <p>
                     Welcome to the Neural Network Designer! This tool helps you build PyTorch models visually by
                     connecting blocks on a canvas.
@@ -3640,7 +3645,7 @@ class MyModel(nn.Module):
               {/* Adding Blocks */}
               <div className="space-y-3">
                 <h3 className="text-lg font-semibold">📦 Adding Blocks</h3>
-                <div className="space-y-2 text-sm text-gray-700">
+                <div className="space-y-2 text-sm text-muted-foreground">
                   <p>
                     <strong>1.</strong> Browse the left sidebar to find different layer types (Input, Linear,
                     Convolution, etc.)
@@ -3660,7 +3665,7 @@ class MyModel(nn.Module):
               {/* Connecting Blocks */}
               <div className="space-y-3">
                 <h3 className="text-lg font-semibold">🔗 Connecting Blocks</h3>
-                <div className="space-y-2 text-sm text-gray-700">
+                <div className="space-y-2 text-sm text-muted-foreground">
                   <p>
                     <strong>1.</strong> Drag from the output handle (right side) of one block
                   </p>
@@ -3679,7 +3684,7 @@ class MyModel(nn.Module):
               {/* Configuring Parameters */}
               <div className="space-y-3">
                 <h3 className="text-lg font-semibold">⚙️ Configuring Parameters</h3>
-                <div className="space-y-2 text-sm text-gray-700">
+                <div className="space-y-2 text-sm text-muted-foreground">
                   <p>
                     <strong>1.</strong> Click on any block to select it
                   </p>
@@ -3698,13 +3703,13 @@ class MyModel(nn.Module):
               {/* Deleting Blocks */}
               <div className="space-y-3">
                 <h3 className="text-lg font-semibold">🗑️ Deleting Blocks</h3>
-                <div className="space-y-2 text-sm text-gray-700">
+                <div className="space-y-2 text-sm text-muted-foreground">
                   <p>
                     <strong>1.</strong> Click on a block to select it (shows selection border)
                   </p>
                   <p>
-                    <strong>2.</strong> Press the <kbd className="px-2 py-1 bg-gray-100 rounded text-xs">Delete</kbd> or{' '}
-                    <kbd className="px-2 py-1 bg-gray-100 rounded text-xs">Backspace</kbd> key
+                    <strong>2.</strong> Press the <kbd className="px-2 py-1 bg-muted rounded text-xs">Delete</kbd> or{' '}
+                    <kbd className="px-2 py-1 bg-muted rounded text-xs">Backspace</kbd> key
                   </p>
                   <p>
                     <strong>3.</strong> The block and its connections will be removed
@@ -3715,11 +3720,11 @@ class MyModel(nn.Module):
               {/* Keyboard Shortcuts */}
               <div className="space-y-3">
                 <h3 className="text-lg font-semibold">⌨️ Keyboard Shortcuts</h3>
-                <div className="space-y-2 text-sm text-gray-700">
+                <div className="space-y-2 text-sm text-muted-foreground">
                   {keyboardShortcuts.map((shortcut, index) => (
                     <div key={index} className="flex items-center justify-between">
                       <p>{shortcut.description}</p>
-                      <kbd className="px-2 py-1 bg-gray-300 rounded text-xs font-semibold">{shortcut.key}</kbd>
+                      <kbd className="px-2 py-1 bg-muted rounded text-xs font-semibold">{shortcut.key}</kbd>
                     </div>
                   ))}
                 </div>
@@ -3728,7 +3733,7 @@ class MyModel(nn.Module):
               {/* Saving, Loading, Importing & Exporting */}
               <div className="space-y-3">
                 <h3 className="text-lg font-semibold">💾 Saving, Loading, Importing & Exporting</h3>
-                <div className="space-y-2 text-sm text-gray-700">
+                <div className="space-y-2 text-sm text-muted-foreground">
                   <p>
                     <strong>To Save:</strong> Click the "Save" button, enter a name, and save it to your browser's local storage.
                   </p>
@@ -3747,7 +3752,7 @@ class MyModel(nn.Module):
               {/* Using Examples */}
               <div className="space-y-3">
                 <h3 className="text-lg font-semibold">📚 Loading Examples</h3>
-                <div className="space-y-2 text-sm text-gray-700">
+                <div className="space-y-2 text-sm text-muted-foreground">
                   <p>
                     <strong>1.</strong> Click the "Load Example" button in the header
                   </p>
@@ -3766,7 +3771,7 @@ class MyModel(nn.Module):
               {/* Generating Code */}
               <div className="space-y-3">
                 <h3 className="text-lg font-semibold">🐍 Generating PyTorch Code</h3>
-                <div className="space-y-2 text-sm text-gray-700">
+                <div className="space-y-2 text-sm text-muted-foreground">
                   <p>
                     <strong>1.</strong> Click "Generate PyTorch Code" when your network is ready
                   </p>
@@ -3785,7 +3790,7 @@ class MyModel(nn.Module):
               {/* Model Analysis */}
               <div className="space-y-3">
                 <h3 className="text-lg font-semibold">📊 Model Analysis</h3>
-                <div className="space-y-2 text-sm text-gray-700">
+                <div className="space-y-2 text-sm text-muted-foreground">
                   <p>
                     <strong>1.</strong> Click "Analyze Model" to get detailed insights
                   </p>
@@ -3804,7 +3809,7 @@ class MyModel(nn.Module):
               {/* Tips */}
               <div className="space-y-3">
                 <h3 className="text-lg font-semibold">💡 Pro Tips</h3>
-                <div className="space-y-2 text-sm text-gray-700">
+                <div className="space-y-2 text-sm text-muted-foreground">
                   <p>• Always start with an Input block to define your data dimensions</p>
                   <p>• Watch tensor shapes to ensure compatibility between layers</p>
                   <p>• Use skip connections (Add/Concatenate blocks) for advanced architectures</p>
@@ -3816,7 +3821,7 @@ class MyModel(nn.Module):
               {/* Available Blocks */}
               <div className="space-y-3">
                 <h3 className="text-lg font-semibold">🧱 Available Block Types</h3>
-                <div className="grid grid-cols-2 gap-4 text-sm text-gray-700">
+                <div className="grid grid-cols-2 gap-4 text-sm text-muted-foreground">
                   <div>
                     <p>
                       <strong>Basic:</strong> Input, Linear, Dropout
@@ -3851,7 +3856,7 @@ class MyModel(nn.Module):
               {/* Feedback & Contact */}
               <div className="space-y-3">
                 <h3 className="text-lg font-semibold">📧 Feedback & Contact</h3>
-                <div className="space-y-2 text-sm text-gray-700">
+                <div className="space-y-2 text-sm text-muted-foreground">
                   <p>
                     Have suggestions, found a bug, or want to request new features? Send your feedback to:{' '}
                     <strong>pmquang87@icloud.com</strong>

--- a/components/nodes/AdaptiveAvgPool2DNode.tsx
+++ b/components/nodes/AdaptiveAvgPool2DNode.tsx
@@ -1,8 +1,9 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { Shrink } from "lucide-react"
 
-export function AdaptiveAvgPool2DNode({ data }: { data: any }) {
+function AdaptiveAvgPool2DNodeImpl({ data }: { data: any }) {
   return (
     <Card className="min-w-[160px] bg-card border-border shadow-sm">
       <Handle type="target" position={Position.Left} className="w-3 h-3 bg-primary" />
@@ -19,3 +20,6 @@ export function AdaptiveAvgPool2DNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const AdaptiveAvgPool2DNode = memo(AdaptiveAvgPool2DNodeImpl)
+AdaptiveAvgPool2DNode.displayName = "AdaptiveAvgPool2DNode"

--- a/components/nodes/AdaptiveInstanceNormNode.tsx
+++ b/components/nodes/AdaptiveInstanceNormNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { GitBranch } from "lucide-react"
 import { calculateOutputShape, formatTensorShape, type TensorShape } from "@/lib/tensor-shape-calculator"
 
-export function AdaptiveInstanceNormNode({ data }: { data: any }) {
+function AdaptiveInstanceNormNodeImpl({ data }: { data: any }) {
   const inputShape: TensorShape = data.inputShape || { batch: 1, features: 512, height: 4, width: 4 }
   const styleShape: TensorShape = data.styleShape || { batch: 1, features: 512 }
   const outputShape = calculateOutputShape("adaptiveInstanceNormNode", [inputShape, styleShape], data)
@@ -44,3 +45,6 @@ export function AdaptiveInstanceNormNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const AdaptiveInstanceNormNode = memo(AdaptiveInstanceNormNodeImpl)
+AdaptiveInstanceNormNode.displayName = "AdaptiveInstanceNormNode"

--- a/components/nodes/AdaptiveMaxPool1DNode.tsx
+++ b/components/nodes/AdaptiveMaxPool1DNode.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 
@@ -9,7 +10,7 @@ interface AdaptiveMaxPool1DNodeProps {
   }
 }
 
-export function AdaptiveMaxPool1DNode({ data }: AdaptiveMaxPool1DNodeProps) {
+function AdaptiveMaxPool1DNodeImpl({ data }: AdaptiveMaxPool1DNodeProps) {
   return (
     <Card className="min-w-[180px] bg-white border-2 border-red-200 shadow-sm">
       <Handle type="target" position={Position.Top} className="w-3 h-3" />
@@ -35,3 +36,6 @@ export function AdaptiveMaxPool1DNode({ data }: AdaptiveMaxPool1DNodeProps) {
     </Card>
   )
 }
+
+export const AdaptiveMaxPool1DNode = memo(AdaptiveMaxPool1DNodeImpl)
+AdaptiveMaxPool1DNode.displayName = "AdaptiveMaxPool1DNode"

--- a/components/nodes/AddNode.tsx
+++ b/components/nodes/AddNode.tsx
@@ -2,9 +2,9 @@ import { Handle, Position, useUpdateNodeInternals } from "@xyflow/react";
 import { Card } from "@/components/ui/card";
 import { Plus } from "lucide-react";
 import { calculateOutputShape, formatTensorShape, type TensorShape } from "@/lib/tensor-shape-calculator";
-import { useEffect } from "react";
+import { useEffect, memo } from "react"
 
-export function AddNode({ id, data }: { id: string; data: any }) {
+function AddNodeImpl({ id, data }: { id: string; data: any }) {
   const updateNodeInternals = useUpdateNodeInternals();
   // data.inputShape is an array of shapes (or undefined) populated by propagateTensorShapes
   const inputShapes: (TensorShape | undefined)[] = Array.isArray(data.inputShape) ? data.inputShape : [];
@@ -63,3 +63,6 @@ export function AddNode({ id, data }: { id: string; data: any }) {
     </Card>
   );
 }
+
+export const AddNode = memo(AddNodeImpl)
+AddNode.displayName = "AddNode"

--- a/components/nodes/AvgPool2DNode.tsx
+++ b/components/nodes/AvgPool2DNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { Shrink } from "lucide-react"
 import { calculateOutputShape, formatTensorShape, type TensorShape } from "@/lib/tensor-shape-calculator"
 
-export function AvgPool2DNode({ data }: { data: any }) {
+function AvgPool2DNodeImpl({ data }: { data: any }) {
   const inputShape: TensorShape = data.inputShape || { batch: 1, channels: 32, height: 28, width: 28 }
   const outputShape = calculateOutputShape("avgpool2dNode", [inputShape], data)
 
@@ -35,3 +36,6 @@ export function AvgPool2DNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const AvgPool2DNode = memo(AvgPool2DNodeImpl)
+AvgPool2DNode.displayName = "AvgPool2DNode"

--- a/components/nodes/BatchNorm1DNode.tsx
+++ b/components/nodes/BatchNorm1DNode.tsx
@@ -1,10 +1,11 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { BarChart3 } from "lucide-react"
 import { formatTensorShape } from "@/lib/tensor-shape-calculator"
 import type { NodeData } from "@/lib/types"
 
-export function BatchNorm1DNode({ data }: { data: NodeData }) {
+function BatchNorm1DNodeImpl({ data }: { data: NodeData }) {
   return (
     <Card className="min-w-[160px] bg-card border-2 border-purple-500/50 shadow-sm">
       <Handle type="target" position={Position.Left} className="w-3 h-3 bg-purple-500 border-2 border-background" />
@@ -27,3 +28,6 @@ export function BatchNorm1DNode({ data }: { data: NodeData }) {
     </Card>
   )
 }
+
+export const BatchNorm1DNode = memo(BatchNorm1DNodeImpl)
+BatchNorm1DNode.displayName = "BatchNorm1DNode"

--- a/components/nodes/BatchNorm2DNode.tsx
+++ b/components/nodes/BatchNorm2DNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { BarChart3 } from "lucide-react"
 import { formatTensorShape } from "@/lib/tensor-shape-calculator"
 
-export function BatchNorm2DNode({ data }: { data: any }) {
+function BatchNorm2DNodeImpl({ data }: { data: any }) {
   return (
     <Card className="min-w-[150px] border-2 border-violet-500/50 bg-card">
       <Handle type="target" position={Position.Left} className="w-3 h-3 bg-violet-500 border-2 border-background" />
@@ -24,3 +25,6 @@ export function BatchNorm2DNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const BatchNorm2DNode = memo(BatchNorm2DNodeImpl)
+BatchNorm2DNode.displayName = "BatchNorm2DNode"

--- a/components/nodes/BatchNorm3DNode.tsx
+++ b/components/nodes/BatchNorm3DNode.tsx
@@ -1,10 +1,11 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { BarChart3 } from "lucide-react"
 import { formatTensorShape } from "@/lib/tensor-shape-calculator"
 import type { NodeData } from "@/lib/types"
 
-export function BatchNorm3DNode({ data }: { data: NodeData }) {
+function BatchNorm3DNodeImpl({ data }: { data: NodeData }) {
   return (
     <Card className="min-w-[150px] border-2 border-violet-500/50 bg-card">
       <Handle type="target" position={Position.Left} className="w-3 h-3 bg-violet-500 border-2 border-background" />
@@ -25,3 +26,6 @@ export function BatchNorm3DNode({ data }: { data: NodeData }) {
     </Card>
   )
 }
+
+export const BatchNorm3DNode = memo(BatchNorm3DNodeImpl)
+BatchNorm3DNode.displayName = "BatchNorm3DNode"

--- a/components/nodes/ChunkNode.tsx
+++ b/components/nodes/ChunkNode.tsx
@@ -1,8 +1,9 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react";
 import { Card } from "@/components/ui/card";
 import { GitBranch } from "lucide-react";
 
-export function ChunkNode({ data }: { data: any }) {
+function ChunkNodeImpl({ data }: { data: any }) {
   return (
     <Card className="min-w-[150px] border-2 border-indigo-500/50 bg-card">
       <Handle type="target" position={Position.Left} className="w-3 h-3 bg-indigo-500 border-2 border-background" />
@@ -33,3 +34,6 @@ export function ChunkNode({ data }: { data: any }) {
     </Card>
   );
 }
+
+export const ChunkNode = memo(ChunkNodeImpl)
+ChunkNode.displayName = "ChunkNode"

--- a/components/nodes/ConcatenateNode.tsx
+++ b/components/nodes/ConcatenateNode.tsx
@@ -2,9 +2,9 @@ import { Handle, Position, useUpdateNodeInternals } from "@xyflow/react";
 import { Card } from "@/components/ui/card";
 import { GitBranch } from "lucide-react";
 import { calculateOutputShape, formatTensorShape, type TensorShape } from "@/lib/tensor-shape-calculator";
-import { useEffect } from "react";
+import { useEffect, memo } from "react"
 
-export function ConcatenateNode({ id, data }: { id: string; data: any }) {
+function ConcatenateNodeImpl({ id, data }: { id: string; data: any }) {
   const updateNodeInternals = useUpdateNodeInternals();
   // data.inputShape is an array of shapes (or undefined) populated by propagateTensorShapes
   const inputShapes: (TensorShape | undefined)[] = Array.isArray(data.inputShape) ? data.inputShape : [];
@@ -64,3 +64,6 @@ export function ConcatenateNode({ id, data }: { id: string; data: any }) {
     </Card>
   );
 }
+
+export const ConcatenateNode = memo(ConcatenateNodeImpl)
+ConcatenateNode.displayName = "ConcatenateNode"

--- a/components/nodes/ConstantNode.tsx
+++ b/components/nodes/ConstantNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { AppWindow } from "lucide-react"
 import { calculateOutputShape, formatTensorShape, type TensorShape } from "@/lib/tensor-shape-calculator"
 
-export function ConstantNode({ data }: { data: any }) {
+function ConstantNodeImpl({ data }: { data: any }) {
   const outputShape = calculateOutputShape("constantNode", [], data)
 
   return (
@@ -28,3 +29,6 @@ export function ConstantNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const ConstantNode = memo(ConstantNodeImpl)
+ConstantNode.displayName = "ConstantNode"

--- a/components/nodes/ContentLossNode.tsx
+++ b/components/nodes/ContentLossNode.tsx
@@ -1,8 +1,9 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react";
 import { Card } from "@/components/ui/card";
 import { BrainCircuit } from "lucide-react";
 
-export function ContentLossNode({ data }: { data: any }) {
+function ContentLossNodeImpl({ data }: { data: any }) {
   return (
     <Card className="w-48 border-2 border-yellow-500/50 bg-card">
       <Handle type="target" position={Position.Left} className="w-3 h-3 bg-yellow-500 border-2 border-background" />
@@ -20,3 +21,6 @@ export function ContentLossNode({ data }: { data: any }) {
     </Card>
   );
 }
+
+export const ContentLossNode = memo(ContentLossNodeImpl)
+ContentLossNode.displayName = "ContentLossNode"

--- a/components/nodes/Conv1DNode.tsx
+++ b/components/nodes/Conv1DNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { Layers } from "lucide-react"
 import { calculateOutputShape, formatTensorShape, type TensorShape } from "@/lib/tensor-shape-calculator"
 
-export function Conv1DNode({ data }: { data: any }) {
+function Conv1DNodeImpl({ data }: { data: any }) {
   const inputShape: TensorShape = data.inputShape || { batch: 1, channels: 1, length: 100 }
   const outputShape = calculateOutputShape("conv1dNode", [inputShape], data)
 
@@ -33,3 +34,6 @@ export function Conv1DNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const Conv1DNode = memo(Conv1DNodeImpl)
+Conv1DNode.displayName = "Conv1DNode"

--- a/components/nodes/Conv2DNode.tsx
+++ b/components/nodes/Conv2DNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { Layers } from "lucide-react"
 import { calculateOutputShape, formatTensorShape, type TensorShape } from "@/lib/tensor-shape-calculator"
 
-export function Conv2DNode({ data }: { data: any }) {
+function Conv2DNodeImpl({ data }: { data: any }) {
   const inputShape: TensorShape = data.inputShape || { channels: 3, height: 28, width: 28 }
   const outputShape = calculateOutputShape("conv2dNode", [inputShape], data)
 
@@ -33,3 +34,6 @@ export function Conv2DNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const Conv2DNode = memo(Conv2DNodeImpl)
+Conv2DNode.displayName = "Conv2DNode"

--- a/components/nodes/Conv3DNode.tsx
+++ b/components/nodes/Conv3DNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { Layers } from "lucide-react"
 import { calculateOutputShape, formatTensorShape, type TensorShape } from "@/lib/tensor-shape-calculator"
 
-export function Conv3DNode({ data }: { data: any }) {
+function Conv3DNodeImpl({ data }: { data: any }) {
   const inputShape: TensorShape = data.inputShape || { batch: 1, channels: 1, depth: 16, height: 16, width: 16 }
   const outputShape = calculateOutputShape("conv3dNode", [inputShape], data)
 
@@ -33,3 +34,6 @@ export function Conv3DNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const Conv3DNode = memo(Conv3DNodeImpl)
+Conv3DNode.displayName = "Conv3DNode"

--- a/components/nodes/ConvTranspose1DNode.tsx
+++ b/components/nodes/ConvTranspose1DNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { Layers } from "lucide-react"
 import { calculateOutputShape, formatTensorShape, type TensorShape } from "@/lib/tensor-shape-calculator"
 
-export function ConvTranspose1DNode({ data }: { data: any }) {
+function ConvTranspose1DNodeImpl({ data }: { data: any }) {
   const inputShape: TensorShape = data.inputShape || { batch: 1, channels: 32, length: 50 }
   const outputShape = calculateOutputShape("convtranspose1dNode", [inputShape], data)
 
@@ -33,3 +34,6 @@ export function ConvTranspose1DNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const ConvTranspose1DNode = memo(ConvTranspose1DNodeImpl)
+ConvTranspose1DNode.displayName = "ConvTranspose1DNode"

--- a/components/nodes/ConvTranspose2DNode.tsx
+++ b/components/nodes/ConvTranspose2DNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { Layers } from "lucide-react"
 import { calculateOutputShape, formatTensorShape, type TensorShape } from "@/lib/tensor-shape-calculator"
 
-export function ConvTranspose2DNode({ data }: { data: any }) {
+function ConvTranspose2DNodeImpl({ data }: { data: any }) {
   const inputShape: TensorShape = data.inputShape || { batch: 1, channels: 32, height: 14, width: 14 }
   const outputShape = calculateOutputShape("convtranspose2dNode", [inputShape], data)
 
@@ -33,3 +34,6 @@ export function ConvTranspose2DNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const ConvTranspose2DNode = memo(ConvTranspose2DNodeImpl)
+ConvTranspose2DNode.displayName = "ConvTranspose2DNode"

--- a/components/nodes/ConvTranspose3DNode.tsx
+++ b/components/nodes/ConvTranspose3DNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { Layers } from "lucide-react"
 import { calculateOutputShape, formatTensorShape, type TensorShape } from "@/lib/tensor-shape-calculator"
 
-export function ConvTranspose3DNode({ data }: { data: any }) {
+function ConvTranspose3DNodeImpl({ data }: { data: any }) {
   const inputShape: TensorShape = data.inputShape || { batch: 1, channels: 32, depth: 8, height: 8, width: 8 }
   const outputShape = calculateOutputShape("convtranspose3dNode", [inputShape], data)
 
@@ -33,3 +34,6 @@ export function ConvTranspose3DNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const ConvTranspose3DNode = memo(ConvTranspose3DNodeImpl)
+ConvTranspose3DNode.displayName = "ConvTranspose3DNode"

--- a/components/nodes/DefaultNode.tsx
+++ b/components/nodes/DefaultNode.tsx
@@ -1,8 +1,9 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react";
 import { Card } from "@/components/ui/card";
 import { Box } from "lucide-react";
 
-export function DefaultNode({ data }: { data: any }) {
+function DefaultNodeImpl({ data }: { data: any }) {
   return (
     <Card className="w-48 border-2 border-gray-500/50 bg-card">
       <Handle type="target" position={Position.Left} className="w-3 h-3 bg-gray-500 border-2 border-background" />
@@ -16,3 +17,6 @@ export function DefaultNode({ data }: { data: any }) {
     </Card>
   );
 }
+
+export const DefaultNode = memo(DefaultNodeImpl)
+DefaultNode.displayName = "DefaultNode"

--- a/components/nodes/DepthwiseConv2DNode.tsx
+++ b/components/nodes/DepthwiseConv2DNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { Layers } from "lucide-react"
 import { calculateOutputShape, formatTensorShape, type TensorShape } from "@/lib/tensor-shape-calculator"
 
-export function DepthwiseConv2DNode({ data }: { data: any }) {
+function DepthwiseConv2DNodeImpl({ data }: { data: any }) {
   const inputShape: TensorShape = data.inputShape || { channels: 32, height: 28, width: 28 }
   const outputShape = calculateOutputShape("depthwiseconv2dNode", [inputShape], data)
 
@@ -33,3 +34,6 @@ export function DepthwiseConv2DNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const DepthwiseConv2DNode = memo(DepthwiseConv2DNodeImpl)
+DepthwiseConv2DNode.displayName = "DepthwiseConv2DNode"

--- a/components/nodes/DownsampleNode.tsx
+++ b/components/nodes/DownsampleNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { ArrowDownLeft } from "lucide-react"
 import { calculateOutputShape, formatTensorShape, type TensorShape } from "@/lib/tensor-shape-calculator"
 
-export function DownsampleNode({ data }: { data: any }) {
+function DownsampleNodeImpl({ data }: { data: any }) {
   const inputShape: TensorShape = data.inputShape || { batch: 1, channels: 512, height: 4, width: 4 }
   const outputShape = calculateOutputShape("downsampleNode", [inputShape], data)
 
@@ -29,3 +30,6 @@ export function DownsampleNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const DownsampleNode = memo(DownsampleNodeImpl)
+DownsampleNode.displayName = "DownsampleNode"

--- a/components/nodes/DropoutNode.tsx
+++ b/components/nodes/DropoutNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { Shield } from "lucide-react"
 import { calculateOutputShape, formatTensorShape, type TensorShape } from "@/lib/tensor-shape-calculator"
 
-export function DropoutNode({ data }: { data: any }) {
+function DropoutNodeImpl({ data }: { data: any }) {
   const inputShape: TensorShape = data.inputShape || { batch: 1, features: 128 }
   const outputShape = calculateOutputShape("dropoutNode", [inputShape], data)
 
@@ -27,3 +28,6 @@ export function DropoutNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const DropoutNode = memo(DropoutNodeImpl)
+DropoutNode.displayName = "DropoutNode"

--- a/components/nodes/EmbeddingNode.tsx
+++ b/components/nodes/EmbeddingNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { Hash } from "lucide-react"
 import { calculateOutputShape, formatTensorShape, type TensorShape } from "@/lib/tensor-shape-calculator"
 
-export function EmbeddingNode({ data }: { data: any }) {
+function EmbeddingNodeImpl({ data }: { data: any }) {
   const inputShape: TensorShape = data.inputShape || { batch: 1, sequence: 128 }
   const outputShape = calculateOutputShape("embeddingNode", [inputShape], data)
 
@@ -30,3 +31,6 @@ export function EmbeddingNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const EmbeddingNode = memo(EmbeddingNodeImpl)
+EmbeddingNode.displayName = "EmbeddingNode"

--- a/components/nodes/FlattenNode.tsx
+++ b/components/nodes/FlattenNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { Minimize2 } from "lucide-react"
 import { formatTensorShape } from "@/lib/tensor-shape-calculator"
 
-export function FlattenNode({ data }: { data: any }) {
+function FlattenNodeImpl({ data }: { data: any }) {
   const inputShape = data.inputShape || { batch: 1, channels: 1, height: 28, width: 28 }
   const outputShape = data.outputShape || { batch: 1, features: 784 }
 
@@ -24,3 +25,6 @@ export function FlattenNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const FlattenNode = memo(FlattenNodeImpl)
+FlattenNode.displayName = "FlattenNode"

--- a/components/nodes/FractionalMaxPool2DNode.tsx
+++ b/components/nodes/FractionalMaxPool2DNode.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 
@@ -10,7 +11,7 @@ interface FractionalMaxPool2DNodeProps {
   }
 }
 
-export function FractionalMaxPool2DNode({ data }: FractionalMaxPool2DNodeProps) {
+function FractionalMaxPool2DNodeImpl({ data }: FractionalMaxPool2DNodeProps) {
   return (
     <Card className="min-w-[180px] bg-white border-2 border-red-200 shadow-sm">
       <Handle type="target" position={Position.Top} className="w-3 h-3" />
@@ -39,3 +40,6 @@ export function FractionalMaxPool2DNode({ data }: FractionalMaxPool2DNodeProps) 
     </Card>
   )
 }
+
+export const FractionalMaxPool2DNode = memo(FractionalMaxPool2DNodeImpl)
+FractionalMaxPool2DNode.displayName = "FractionalMaxPool2DNode"

--- a/components/nodes/GELUNode.tsx
+++ b/components/nodes/GELUNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { Zap } from "lucide-react"
 import { calculateOutputShape, formatTensorShape, type TensorShape } from "@/lib/tensor-shape-calculator"
 
-export function GELUNode({ data }: { data: any }) {
+function GELUNodeImpl({ data }: { data: any }) {
   const inputShape: TensorShape = data.inputShape
   const outputShape = calculateOutputShape("geluNode", [inputShape], data)
 
@@ -24,3 +25,6 @@ export function GELUNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const GELUNode = memo(GELUNodeImpl)
+GELUNode.displayName = "GELUNode"

--- a/components/nodes/GRUNode.tsx
+++ b/components/nodes/GRUNode.tsx
@@ -1,8 +1,9 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { GitBranch } from "lucide-react"
 
-export function GRUNode({ data }: { data: any }) {
+function GRUNodeImpl({ data }: { data: any }) {
   return (
     <Card className="min-w-[160px] bg-card border-border shadow-sm">
       <Handle type="target" position={Position.Left} className="w-3 h-3 bg-primary" />
@@ -25,3 +26,6 @@ export function GRUNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const GRUNode = memo(GRUNodeImpl)
+GRUNode.displayName = "GRUNode"

--- a/components/nodes/GroupNormNode.tsx
+++ b/components/nodes/GroupNormNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { BarChart3 } from "lucide-react"
 import { formatTensorShape } from "@/lib/tensor-shape-calculator"
 
-export function GroupNormNode({ data }: { data: any }) {
+function GroupNormNodeImpl({ data }: { data: any }) {
   return (
     <Card className="min-w-[160px] bg-card border-border shadow-sm">
       <Handle type="target" position={Position.Left} className="w-3 h-3 bg-primary" />
@@ -30,3 +31,6 @@ export function GroupNormNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const GroupNormNode = memo(GroupNormNodeImpl)
+GroupNormNode.displayName = "GroupNormNode"

--- a/components/nodes/HardsigmoidNode.tsx
+++ b/components/nodes/HardsigmoidNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { Zap } from "lucide-react"
 import { calculateOutputShape, formatTensorShape, type TensorShape } from "@/lib/tensor-shape-calculator"
 
-export function HardsigmoidNode({ data }: { data: any }) {
+function HardsigmoidNodeImpl({ data }: { data: any }) {
   const inputShape: TensorShape = data.inputShape
   const outputShape = calculateOutputShape("hardsigmoidNode", [inputShape], data)
 
@@ -24,3 +25,6 @@ export function HardsigmoidNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const HardsigmoidNode = memo(HardsigmoidNodeImpl)
+HardsigmoidNode.displayName = "HardsigmoidNode"

--- a/components/nodes/HardswishNode.tsx
+++ b/components/nodes/HardswishNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { Zap } from "lucide-react"
 import { calculateOutputShape, formatTensorShape, type TensorShape } from "@/lib/tensor-shape-calculator"
 
-export function HardswishNode({ data }: { data: any }) {
+function HardswishNodeImpl({ data }: { data: any }) {
   const inputShape: TensorShape = data.inputShape
   const outputShape = calculateOutputShape("hardswishNode", [inputShape], data)
 
@@ -24,3 +25,6 @@ export function HardswishNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const HardswishNode = memo(HardswishNodeImpl)
+HardswishNode.displayName = "HardswishNode"

--- a/components/nodes/InputNode.tsx
+++ b/components/nodes/InputNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { LogIn } from "lucide-react"
 import { formatTensorShape } from "@/lib/tensor-shape-calculator"
 
-export function InputNode({ data }: { data: any }) {
+function InputNodeImpl({ data }: { data: any }) {
   return (
     <Card className="min-w-[160px] bg-card border-green-500/50 shadow-sm">
       <div className="p-3">
@@ -24,3 +25,6 @@ export function InputNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const InputNode = memo(InputNodeImpl)
+InputNode.displayName = "InputNode"

--- a/components/nodes/InstanceNorm1DNode.tsx
+++ b/components/nodes/InstanceNorm1DNode.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import type { NodeData } from "@/lib/types"
 import { formatTensorShape } from "@/lib/tensor-shape-calculator"
@@ -6,7 +7,7 @@ interface InstanceNorm1DNodeProps {
   data: NodeData
 }
 
-export function InstanceNorm1DNode({ data }: InstanceNorm1DNodeProps) {
+function InstanceNorm1DNodeImpl({ data }: InstanceNorm1DNodeProps) {
   return (
     <div className="bg-cyan-100 border-2 border-cyan-300 rounded-lg p-3 min-w-[140px]">
       <Handle type="target" position={Position.Left} />
@@ -24,3 +25,6 @@ export function InstanceNorm1DNode({ data }: InstanceNorm1DNodeProps) {
     </div>
   )
 }
+
+export const InstanceNorm1DNode = memo(InstanceNorm1DNodeImpl)
+InstanceNorm1DNode.displayName = "InstanceNorm1DNode"

--- a/components/nodes/InstanceNorm2DNode.tsx
+++ b/components/nodes/InstanceNorm2DNode.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import type { NodeData } from "@/lib/types"
 import { formatTensorShape } from "@/lib/tensor-shape-calculator"
@@ -6,7 +7,7 @@ interface InstanceNorm2DNodeProps {
   data: NodeData
 }
 
-export function InstanceNorm2DNode({ data }: InstanceNorm2DNodeProps) {
+function InstanceNorm2DNodeImpl({ data }: InstanceNorm2DNodeProps) {
   return (
     <div className="bg-cyan-100 border-2 border-cyan-300 rounded-lg p-3 min-w-[140px]">
       <Handle type="target" position={Position.Left} />
@@ -24,3 +25,6 @@ export function InstanceNorm2DNode({ data }: InstanceNorm2DNodeProps) {
     </div>
   )
 }
+
+export const InstanceNorm2DNode = memo(InstanceNorm2DNodeImpl)
+InstanceNorm2DNode.displayName = "InstanceNorm2DNode"

--- a/components/nodes/InstanceNorm3DNode.tsx
+++ b/components/nodes/InstanceNorm3DNode.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import type { NodeData } from "@/lib/types"
 import { formatTensorShape } from "@/lib/tensor-shape-calculator"
@@ -6,7 +7,7 @@ interface InstanceNorm3DNodeProps {
   data: NodeData
 }
 
-export function InstanceNorm3DNode({ data }: InstanceNorm3DNodeProps) {
+function InstanceNorm3DNodeImpl({ data }: InstanceNorm3DNodeProps) {
   return (
     <div className="bg-cyan-100 border-2 border-cyan-300 rounded-lg p-3 min-w-[140px]">
       <Handle type="target" position={Position.Left} />
@@ -24,3 +25,6 @@ export function InstanceNorm3DNode({ data }: InstanceNorm3DNodeProps) {
     </div>
   )
 }
+
+export const InstanceNorm3DNode = memo(InstanceNorm3DNodeImpl)
+InstanceNorm3DNode.displayName = "InstanceNorm3DNode"

--- a/components/nodes/InvertedResidualBlockNode.tsx
+++ b/components/nodes/InvertedResidualBlockNode.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import type { NodeData } from "@/lib/types"
 
@@ -5,7 +6,7 @@ interface InvertedResidualBlockNodeProps {
   data: NodeData
 }
 
-export function InvertedResidualBlockNode({ data }: InvertedResidualBlockNodeProps) {
+function InvertedResidualBlockNodeImpl({ data }: InvertedResidualBlockNodeProps) {
   return (
     <div className="bg-blue-100 border-2 border-blue-300 rounded-lg p-3 min-w-[160px]">
       <Handle type="target" position={Position.Left} />
@@ -26,3 +27,6 @@ export function InvertedResidualBlockNode({ data }: InvertedResidualBlockNodePro
     </div>
   )
 }
+
+export const InvertedResidualBlockNode = memo(InvertedResidualBlockNodeImpl)
+InvertedResidualBlockNode.displayName = "InvertedResidualBlockNode"

--- a/components/nodes/LPPool2DNode.tsx
+++ b/components/nodes/LPPool2DNode.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 
@@ -11,7 +12,7 @@ interface LPPool2DNodeProps {
   }
 }
 
-export function LPPool2DNode({ data }: LPPool2DNodeProps) {
+function LPPool2DNodeImpl({ data }: LPPool2DNodeProps) {
   return (
     <Card className="min-w-[180px] bg-white border-2 border-red-200 shadow-sm">
       <Handle type="target" position={Position.Top} className="w-3 h-3" />
@@ -41,3 +42,6 @@ export function LPPool2DNode({ data }: LPPool2DNodeProps) {
     </Card>
   )
 }
+
+export const LPPool2DNode = memo(LPPool2DNodeImpl)
+LPPool2DNode.displayName = "LPPool2DNode"

--- a/components/nodes/LSTMNode.tsx
+++ b/components/nodes/LSTMNode.tsx
@@ -1,8 +1,9 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { GitBranch } from "lucide-react"
 
-export function LSTMNode({ data }: { data: any }) {
+function LSTMNodeImpl({ data }: { data: any }) {
   return (
     <Card className="min-w-[150px] border-2 border-orange-500/50 bg-card">
       <Handle type="target" position={Position.Left} className="w-3 h-3 bg-orange-500 border-2 border-background" />
@@ -21,3 +22,6 @@ export function LSTMNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const LSTMNode = memo(LSTMNodeImpl)
+LSTMNode.displayName = "LSTMNode"

--- a/components/nodes/LayerNormNode.tsx
+++ b/components/nodes/LayerNormNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { Network } from "lucide-react"
 import { formatTensorShape } from "@/lib/tensor-shape-calculator"
 
-export function LayerNormNode({ data }: { data: any }) {
+function LayerNormNodeImpl({ data }: { data: any }) {
   return (
     <Card className="w-56 border-2 border-gray-500/50 bg-card">
       <Handle type="target" position={Position.Left} className="w-3 h-3 bg-gray-500 border-2 border-background" />
@@ -26,3 +27,6 @@ export function LayerNormNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const LayerNormNode = memo(LayerNormNodeImpl)
+LayerNormNode.displayName = "LayerNormNode"

--- a/components/nodes/LeakyReLUNode.tsx
+++ b/components/nodes/LeakyReLUNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { Zap } from "lucide-react"
 import { calculateOutputShape, formatTensorShape, type TensorShape } from "@/lib/tensor-shape-calculator"
 
-export function LeakyReLUNode({ data }: { data: any }) {
+function LeakyReLUNodeImpl({ data }: { data: any }) {
   const inputShape: TensorShape = data.inputShape || { batch: 1, features: 128 }
   const outputShape = calculateOutputShape("leakyreluNode", [inputShape], data)
 
@@ -29,3 +30,6 @@ export function LeakyReLUNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const LeakyReLUNode = memo(LeakyReLUNodeImpl)
+LeakyReLUNode.displayName = "LeakyReLUNode"

--- a/components/nodes/LinearNode.tsx
+++ b/components/nodes/LinearNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { Layers } from "lucide-react"
 import { calculateOutputShape, formatTensorShape, type TensorShape } from "@/lib/tensor-shape-calculator"
 
-export function LinearNode({ data }: { data: any }) {
+function LinearNodeImpl({ data }: { data: any }) {
   const inputShape: TensorShape = data.inputShape || { batch: 1, features: 128 }
   const outputShape = calculateOutputShape("linearNode", [inputShape], data)
 
@@ -30,3 +31,6 @@ export function LinearNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const LinearNode = memo(LinearNodeImpl)
+LinearNode.displayName = "LinearNode"

--- a/components/nodes/MBConvNode.tsx
+++ b/components/nodes/MBConvNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { Layers } from "lucide-react"
 import { calculateOutputShape, formatTensorShape, type TensorShape } from "@/lib/tensor-shape-calculator"
 
-export function MBConvNode({ data }: { data: any }) {
+function MBConvNodeImpl({ data }: { data: any }) {
   const inputShape: TensorShape = data.inputShape || { batch: 1, channels: 3, height: 224, width: 224 }
   const outputShape = calculateOutputShape("mbconvNode", [inputShape], data)
 
@@ -34,3 +35,6 @@ export function MBConvNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const MBConvNode = memo(MBConvNodeImpl)
+MBConvNode.displayName = "MBConvNode"

--- a/components/nodes/MaxPool1DNode.tsx
+++ b/components/nodes/MaxPool1DNode.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 
@@ -10,7 +11,7 @@ interface MaxPool1DNodeProps {
   }
 }
 
-export function MaxPool1DNode({ data }: MaxPool1DNodeProps) {
+function MaxPool1DNodeImpl({ data }: MaxPool1DNodeProps) {
   return (
     <Card className="min-w-[180px] bg-white border-2 border-red-200 shadow-sm">
       <Handle type="target" position={Position.Top} className="w-3 h-3" />
@@ -37,3 +38,6 @@ export function MaxPool1DNode({ data }: MaxPool1DNodeProps) {
     </Card>
   )
 }
+
+export const MaxPool1DNode = memo(MaxPool1DNodeImpl)
+MaxPool1DNode.displayName = "MaxPool1DNode"

--- a/components/nodes/MaxPool2DNode.tsx
+++ b/components/nodes/MaxPool2DNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { Shrink } from "lucide-react"
 import { calculateOutputShape, formatTensorShape, type TensorShape } from "@/lib/tensor-shape-calculator"
 
-export function MaxPool2DNode({ data }: { data: any }) {
+function MaxPool2DNodeImpl({ data }: { data: any }) {
   const inputShape: TensorShape = data.inputShape || { batch: 1, channels: 32, height: 28, width: 28 }
   const outputShape = calculateOutputShape("maxpool2dNode", [inputShape], data)
 
@@ -31,3 +32,6 @@ export function MaxPool2DNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const MaxPool2DNode = memo(MaxPool2DNodeImpl)
+MaxPool2DNode.displayName = "MaxPool2DNode"

--- a/components/nodes/MaxPool3DNode.tsx
+++ b/components/nodes/MaxPool3DNode.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 
@@ -10,7 +11,7 @@ interface MaxPool3DNodeProps {
   }
 }
 
-export function MaxPool3DNode({ data }: MaxPool3DNodeProps) {
+function MaxPool3DNodeImpl({ data }: MaxPool3DNodeProps) {
   return (
     <Card className="min-w-[180px] bg-white border-2 border-red-200 shadow-sm">
       <Handle type="target" position={Position.Top} className="w-3 h-3" />
@@ -39,3 +40,6 @@ export function MaxPool3DNode({ data }: MaxPool3DNodeProps) {
     </Card>
   )
 }
+
+export const MaxPool3DNode = memo(MaxPool3DNodeImpl)
+MaxPool3DNode.displayName = "MaxPool3DNode"

--- a/components/nodes/MishNode.tsx
+++ b/components/nodes/MishNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { Zap } from "lucide-react"
 import { calculateOutputShape, formatTensorShape, type TensorShape } from "@/lib/tensor-shape-calculator"
 
-export function MishNode({ data }: { data: any }) {
+function MishNodeImpl({ data }: { data: any }) {
   const inputShape: TensorShape = data.inputShape
   const outputShape = calculateOutputShape("mishNode", [inputShape], data)
 
@@ -24,3 +25,6 @@ export function MishNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const MishNode = memo(MishNodeImpl)
+MishNode.displayName = "MishNode"

--- a/components/nodes/MoENode.tsx
+++ b/components/nodes/MoENode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { Boxes } from "lucide-react"
 import { calculateOutputShape, formatTensorShape, type TensorShape } from "@/lib/tensor-shape-calculator"
 
-export function MoENode({ data }: { data: any }) {
+function MoENodeImpl({ data }: { data: any }) {
   const inputShape: TensorShape = data.inputShape
   const outputShape = calculateOutputShape("moeNode", [inputShape], data)
 
@@ -30,3 +31,6 @@ export function MoENode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const MoENode = memo(MoENodeImpl)
+MoENode.displayName = "MoENode"

--- a/components/nodes/MultiheadAttentionNode.tsx
+++ b/components/nodes/MultiheadAttentionNode.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import type { NodeData } from "@/lib/types"
 import { formatTensorShape } from "@/lib/tensor-shape-calculator"
@@ -6,7 +7,7 @@ interface MultiheadAttentionNodeProps {
   data: NodeData
 }
 
-export function MultiheadAttentionNode({ data }: MultiheadAttentionNodeProps) {
+function MultiheadAttentionNodeImpl({ data }: MultiheadAttentionNodeProps) {
   return (
     <div className="bg-purple-100 border-2 border-purple-300 rounded-lg p-3 min-w-[160px]">
       <Handle type="target" position={Position.Left} id="query" style={{ top: "25%" }} />
@@ -23,3 +24,6 @@ export function MultiheadAttentionNode({ data }: MultiheadAttentionNodeProps) {
     </div>
   )
 }
+
+export const MultiheadAttentionNode = memo(MultiheadAttentionNodeImpl)
+MultiheadAttentionNode.displayName = "MultiheadAttentionNode"

--- a/components/nodes/MultiplyNode.tsx
+++ b/components/nodes/MultiplyNode.tsx
@@ -2,7 +2,7 @@ import { Handle, Position, useUpdateNodeInternals } from "@xyflow/react";
 import { Card } from "@/components/ui/card";
 import { X } from "lucide-react";
 import { calculateOutputShape, formatTensorShape, type TensorShape } from "@/lib/tensor-shape-calculator";
-import { useEffect } from "react";
+import { useEffect, memo } from "react"
 
 interface MultiplyNodeData {
   inputShape?: (TensorShape | undefined)[]
@@ -10,7 +10,7 @@ interface MultiplyNodeData {
   [key: string]: unknown
 }
 
-export function MultiplyNode({ id, data }: { id: string; data: MultiplyNodeData }) {
+function MultiplyNodeImpl({ id, data }: { id: string; data: MultiplyNodeData }) {
   const updateNodeInternals = useUpdateNodeInternals();
   // data.inputShape is an array of shapes (or undefined) populated by propagateTensorShapes
   const inputShapes: (TensorShape | undefined)[] = Array.isArray(data.inputShape) ? data.inputShape : [];
@@ -70,3 +70,6 @@ export function MultiplyNode({ id, data }: { id: string; data: MultiplyNodeData 
     </Card>
   );
 }
+
+export const MultiplyNode = memo(MultiplyNodeImpl)
+MultiplyNode.displayName = "MultiplyNode"

--- a/components/nodes/NoiseNode.tsx
+++ b/components/nodes/NoiseNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { Waves } from "lucide-react"
 import { calculateOutputShape, formatTensorShape, type TensorShape } from "@/lib/tensor-shape-calculator"
 
-export function NoiseNode({ data }: { data: any }) {
+function NoiseNodeImpl({ data }: { data: any }) {
   const inputShape: TensorShape = data.inputShape || { batch: 1, features: 512, height: 4, width: 4 }
   const outputShape = calculateOutputShape("noiseNode", [inputShape], data)
 
@@ -31,3 +32,6 @@ export function NoiseNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const NoiseNode = memo(NoiseNodeImpl)
+NoiseNode.displayName = "NoiseNode"

--- a/components/nodes/OutputNode.tsx
+++ b/components/nodes/OutputNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { LogOut } from "lucide-react"
 import { formatTensorShape, type TensorShape } from "@/lib/tensor-shape-calculator"
 
-export function OutputNode({ data }: { data: any }) {
+function OutputNodeImpl({ data }: { data: any }) {
   // For output nodes, we typically show the incoming tensor shape
   const inputShape: TensorShape | undefined = Array.isArray(data.inputShape)
     ? data.inputShape[0]
@@ -32,3 +33,6 @@ export function OutputNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const OutputNode = memo(OutputNodeImpl)
+OutputNode.displayName = "OutputNode"

--- a/components/nodes/RMSNormNode.tsx
+++ b/components/nodes/RMSNormNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { Network } from "lucide-react"
 import { formatTensorShape } from "@/lib/tensor-shape-calculator"
 
-export function RMSNormNode({ data }: { data: any }) {
+function RMSNormNodeImpl({ data }: { data: any }) {
   return (
     <Card className="w-56 border-2 border-cyan-500/50 bg-card">
       <Handle type="target" position={Position.Left} className="w-3 h-3 bg-cyan-500 border-2 border-background" />
@@ -26,3 +27,6 @@ export function RMSNormNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const RMSNormNode = memo(RMSNormNodeImpl)
+RMSNormNode.displayName = "RMSNormNode"

--- a/components/nodes/RNNNode.tsx
+++ b/components/nodes/RNNNode.tsx
@@ -1,8 +1,9 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { GitBranch } from "lucide-react"
 
-export function RNNNode({ data }: { data: any }) {
+function RNNNodeImpl({ data }: { data: any }) {
   return (
     <Card className="min-w-[160px] bg-card border-border shadow-sm">
       <Handle type="target" position={Position.Left} className="w-3 h-3 bg-primary" />
@@ -25,3 +26,6 @@ export function RNNNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const RNNNode = memo(RNNNodeImpl)
+RNNNode.displayName = "RNNNode"

--- a/components/nodes/ReLUNode.tsx
+++ b/components/nodes/ReLUNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { BrainCircuit } from "lucide-react"
 import { formatTensorShape } from "@/lib/tensor-shape-calculator"
 
-export function ReLUNode({ data }: { data: any }) {
+function ReLUNodeImpl({ data }: { data: any }) {
   return (
     <Card className="w-48 border-2 border-red-500/50 bg-card">
       <Handle type="target" position={Position.Left} className="w-3 h-3 bg-red-500 border-2 border-background" />
@@ -21,3 +22,6 @@ export function ReLUNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const ReLUNode = memo(ReLUNodeImpl)
+ReLUNode.displayName = "ReLUNode"

--- a/components/nodes/ReshapeNode.tsx
+++ b/components/nodes/ReshapeNode.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react";
 import { Card } from "@/components/ui/card";
 import { Layers } from "lucide-react";
@@ -8,7 +9,7 @@ interface ReshapeNodeData {
   inputShape?: TensorShape
 }
 
-export function ReshapeNode({ data }: { data: ReshapeNodeData }) {
+function ReshapeNodeImpl({ data }: { data: ReshapeNodeData }) {
   const inputShape: TensorShape | undefined = data.inputShape;
 
   const outputShape = calculateOutputShape("reshapeNode", [(inputShape || {}) as TensorShape], { targetShape: data.targetShape });
@@ -50,3 +51,6 @@ export function ReshapeNode({ data }: { data: ReshapeNodeData }) {
     </Card>
   );
 }
+
+export const ReshapeNode = memo(ReshapeNodeImpl)
+ReshapeNode.displayName = "ReshapeNode"

--- a/components/nodes/SEBlockNode.tsx
+++ b/components/nodes/SEBlockNode.tsx
@@ -1,7 +1,8 @@
+import { memo } from "react"
 import { Handle, Position, type NodeProps } from "@xyflow/react";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 
-export function SEBlockNode({ data }: NodeProps) {
+function SEBlockNodeImpl({ data }: NodeProps) {
   return (
     <Card className="w-48">
       <CardHeader className="p-2">
@@ -16,3 +17,6 @@ export function SEBlockNode({ data }: NodeProps) {
     </Card>
   );
 }
+
+export const SEBlockNode = memo(SEBlockNodeImpl)
+SEBlockNode.displayName = "SEBlockNode"

--- a/components/nodes/SEBottleneckNode.tsx
+++ b/components/nodes/SEBottleneckNode.tsx
@@ -1,7 +1,8 @@
+import { memo } from "react"
 import { Handle, Position, type NodeProps } from "@xyflow/react";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 
-export function SEBottleneckNode({ data }: NodeProps) {
+function SEBottleneckNodeImpl({ data }: NodeProps) {
   return (
     <Card className="w-56">
       <CardHeader className="p-2">
@@ -18,3 +19,6 @@ export function SEBottleneckNode({ data }: NodeProps) {
     </Card>
   );
 }
+
+export const SEBottleneckNode = memo(SEBottleneckNodeImpl)
+SEBottleneckNode.displayName = "SEBottleneckNode"

--- a/components/nodes/ScaledDotProductAttentionNode.tsx
+++ b/components/nodes/ScaledDotProductAttentionNode.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import type { NodeData } from "@/lib/types"
 
@@ -5,7 +6,7 @@ interface ScaledDotProductAttentionNodeProps {
   data: NodeData
 }
 
-export function ScaledDotProductAttentionNode({ data }: ScaledDotProductAttentionNodeProps) {
+function ScaledDotProductAttentionNodeImpl({ data }: ScaledDotProductAttentionNodeProps) {
   return (
     <div className="bg-blue-100 border-2 border-blue-300 rounded-lg p-3 min-w-[160px]">
       <Handle type="target" position={Position.Left} id="query" style={{ top: "25%" }} />
@@ -24,3 +25,6 @@ export function ScaledDotProductAttentionNode({ data }: ScaledDotProductAttentio
     </div>
   )
 }
+
+export const ScaledDotProductAttentionNode = memo(ScaledDotProductAttentionNodeImpl)
+ScaledDotProductAttentionNode.displayName = "ScaledDotProductAttentionNode"

--- a/components/nodes/SelectNode.tsx
+++ b/components/nodes/SelectNode.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import type { HelpContent } from "@/lib/types"
 import { HelpCircle } from "lucide-react"
@@ -47,7 +48,7 @@ const selectNodeHelp: HelpContent = {
   ]
 }
 
-export function SelectNode({ data }: SelectNodeProps) {
+function SelectNodeImpl({ data }: SelectNodeProps) {
   return (
     <div className="bg-purple-100 border-2 border-purple-300 rounded-lg p-3 min-w-[120px]">
       <Handle type="target" position={Position.Left} />
@@ -80,3 +81,6 @@ export function SelectNode({ data }: SelectNodeProps) {
     </div>
   )
 }
+
+export const SelectNode = memo(SelectNodeImpl)
+SelectNode.displayName = "SelectNode"

--- a/components/nodes/SeparableConv2DNode.tsx
+++ b/components/nodes/SeparableConv2DNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { Layers } from "lucide-react"
 import { calculateOutputShape, formatTensorShape, type TensorShape } from "@/lib/tensor-shape-calculator"
 
-export function SeparableConv2DNode({ data }: { data: any }) {
+function SeparableConv2DNodeImpl({ data }: { data: any }) {
   const inputShape: TensorShape = data.inputShape || { channels: 3, height: 28, width: 28 };
   const outputShape = calculateOutputShape("separableconv2dNode", [inputShape], data);
 
@@ -32,3 +33,6 @@ export function SeparableConv2DNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const SeparableConv2DNode = memo(SeparableConv2DNodeImpl)
+SeparableConv2DNode.displayName = "SeparableConv2DNode"

--- a/components/nodes/SiLUNode.tsx
+++ b/components/nodes/SiLUNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { Zap } from "lucide-react"
 import { calculateOutputShape, formatTensorShape, type TensorShape } from "@/lib/tensor-shape-calculator"
 
-export function SiLUNode({ data }: { data: any }) {
+function SiLUNodeImpl({ data }: { data: any }) {
   const inputShape: TensorShape = data.inputShape
   const outputShape = calculateOutputShape("siluNode", [inputShape], data)
 
@@ -24,3 +25,6 @@ export function SiLUNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const SiLUNode = memo(SiLUNodeImpl)
+SiLUNode.displayName = "SiLUNode"

--- a/components/nodes/SigmoidNode.tsx
+++ b/components/nodes/SigmoidNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { Sigma } from "lucide-react"
 import { formatTensorShape } from "@/lib/tensor-shape-calculator"
 
-export function SigmoidNode({ data }: { data: any }) {
+function SigmoidNodeImpl({ data }: { data: any }) {
   return (
     <Card className="w-48 border-2 border-orange-500/50 bg-card">
       <Handle type="target" position={Position.Left} className="w-3 h-3 bg-orange-500 border-2 border-background" />
@@ -21,3 +22,6 @@ export function SigmoidNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const SigmoidNode = memo(SigmoidNodeImpl)
+SigmoidNode.displayName = "SigmoidNode"

--- a/components/nodes/SoftmaxNode.tsx
+++ b/components/nodes/SoftmaxNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { Zap } from "lucide-react"
 import { calculateOutputShape, formatTensorShape, type TensorShape } from "@/lib/tensor-shape-calculator"
 
-export function SoftmaxNode({ data }: { data: any }) {
+function SoftmaxNodeImpl({ data }: { data: any }) {
   const inputShape: TensorShape = data.inputShape || { batch: 1, features: 128 }
   const outputShape = calculateOutputShape("softmaxNode", [inputShape], data)
 
@@ -29,3 +30,6 @@ export function SoftmaxNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const SoftmaxNode = memo(SoftmaxNodeImpl)
+SoftmaxNode.displayName = "SoftmaxNode"

--- a/components/nodes/SsmNode.tsx
+++ b/components/nodes/SsmNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { BrainCircuit } from "lucide-react"
 import { calculateOutputShape, formatTensorShape, type TensorShape } from "@/lib/tensor-shape-calculator"
 
-export function SsmNode({ data }: { data: any }) {
+function SsmNodeImpl({ data }: { data: any }) {
   const inputShape: TensorShape = data.inputShape || { batch: 1, channels: 1, features: 512 }
   const outputShape = calculateOutputShape("ssmNode", [inputShape], data)
 
@@ -32,3 +33,6 @@ export function SsmNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const SsmNode = memo(SsmNodeImpl)
+SsmNode.displayName = "SsmNode"

--- a/components/nodes/StyleLossNode.tsx
+++ b/components/nodes/StyleLossNode.tsx
@@ -1,8 +1,9 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react";
 import { Card } from "@/components/ui/card";
 import { BrainCircuit } from "lucide-react";
 
-export function StyleLossNode({ data }: { data: any }) {
+function StyleLossNodeImpl({ data }: { data: any }) {
   return (
     <Card className="w-48 border-2 border-purple-500/50 bg-card">
       <Handle type="target" position={Position.Left} className="w-3 h-3 bg-purple-500 border-2 border-background" />
@@ -20,3 +21,6 @@ export function StyleLossNode({ data }: { data: any }) {
     </Card>
   );
 }
+
+export const StyleLossNode = memo(StyleLossNodeImpl)
+StyleLossNode.displayName = "StyleLossNode"

--- a/components/nodes/TanhNode.tsx
+++ b/components/nodes/TanhNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { Waves } from "lucide-react"
 import { formatTensorShape } from "@/lib/tensor-shape-calculator"
 
-export function TanhNode({ data }: { data: any }) {
+function TanhNodeImpl({ data }: { data: any }) {
   return (
     <Card className="min-w-[120px] border-2 border-yellow-500/50 bg-card">
       <Handle type="target" position={Position.Left} className="w-3 h-3 bg-yellow-500 border-2 border-background" />
@@ -21,3 +22,6 @@ export function TanhNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const TanhNode = memo(TanhNodeImpl)
+TanhNode.displayName = "TanhNode"

--- a/components/nodes/TimeDistributedLinearNode.tsx
+++ b/components/nodes/TimeDistributedLinearNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { BarChart3 } from "lucide-react"
 import { calculateOutputShape, formatTensorShape, type TensorShape } from "@/lib/tensor-shape-calculator"
 
-export function TimeDistributedLinearNode({ data }: { data: any }) {
+function TimeDistributedLinearNodeImpl({ data }: { data: any }) {
   const inputShape: TensorShape = data.inputShape || { batch: 1, channels: 100, features: 512 }
   const outputShape = calculateOutputShape("timeDistributedLinearNode", [inputShape], data)
 
@@ -30,3 +31,6 @@ export function TimeDistributedLinearNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const TimeDistributedLinearNode = memo(TimeDistributedLinearNodeImpl)
+TimeDistributedLinearNode.displayName = "TimeDistributedLinearNode"

--- a/components/nodes/TransformerDecoderLayerNode.tsx
+++ b/components/nodes/TransformerDecoderLayerNode.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import type { NodeData } from "@/lib/types"
 
@@ -5,7 +6,7 @@ interface TransformerDecoderLayerNodeProps {
   data: NodeData
 }
 
-export function TransformerDecoderLayerNode({ data }: TransformerDecoderLayerNodeProps) {
+function TransformerDecoderLayerNodeImpl({ data }: TransformerDecoderLayerNodeProps) {
   return (
     <div className="bg-violet-100 border-2 border-violet-300 rounded-lg p-3 min-w-[180px]">
       <Handle type="target" position={Position.Left} id="tgt" style={{ top: "33%" }} />
@@ -26,3 +27,6 @@ export function TransformerDecoderLayerNode({ data }: TransformerDecoderLayerNod
     </div>
   )
 }
+
+export const TransformerDecoderLayerNode = memo(TransformerDecoderLayerNodeImpl)
+TransformerDecoderLayerNode.displayName = "TransformerDecoderLayerNode"

--- a/components/nodes/TransformerEncoderLayerNode.tsx
+++ b/components/nodes/TransformerEncoderLayerNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { Layers } from "lucide-react"
 import { formatTensorShape } from "@/lib/tensor-shape-calculator"
 
-export function TransformerEncoderLayerNode({ data }: { data: any }) {
+function TransformerEncoderLayerNodeImpl({ data }: { data: any }) {
   return (
     <Card className="w-64 bg-card border-purple-500/50 shadow-sm">
       <Handle type="target" position={Position.Left} className="w-3 h-3 bg-primary" />
@@ -30,3 +31,6 @@ export function TransformerEncoderLayerNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const TransformerEncoderLayerNode = memo(TransformerEncoderLayerNodeImpl)
+TransformerEncoderLayerNode.displayName = "TransformerEncoderLayerNode"

--- a/components/nodes/TransposeNode.tsx
+++ b/components/nodes/TransposeNode.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { formatTensorShape, type TensorShape } from "@/lib/tensor-shape-calculator"
 
@@ -12,7 +13,7 @@ interface TransposeNodeProps {
   data: TransposeNodeData
 }
 
-export function TransposeNode({ data }: TransposeNodeProps) {
+function TransposeNodeImpl({ data }: TransposeNodeProps) {
   return (
     <div className="bg-orange-100 border-2 border-orange-300 rounded-lg p-3 min-w-[120px]">
       <Handle type="target" position={Position.Left} />
@@ -30,3 +31,6 @@ export function TransposeNode({ data }: TransposeNodeProps) {
     </div>
   )
 }
+
+export const TransposeNode = memo(TransposeNodeImpl)
+TransposeNode.displayName = "TransposeNode"

--- a/components/nodes/UpsampleNode.tsx
+++ b/components/nodes/UpsampleNode.tsx
@@ -1,9 +1,10 @@
+import { memo } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { ArrowUpRight } from "lucide-react"
 import { calculateOutputShape, formatTensorShape, type TensorShape } from "@/lib/tensor-shape-calculator"
 
-export function UpsampleNode({ data }: { data: any }) {
+function UpsampleNodeImpl({ data }: { data: any }) {
   const inputShape: TensorShape = data.inputShape || { batch: 1, channels: 512, height: 4, width: 4 }
   const outputShape = calculateOutputShape("upsampleNode", [inputShape], data)
 
@@ -29,3 +30,6 @@ export function UpsampleNode({ data }: { data: any }) {
     </Card>
   )
 }
+
+export const UpsampleNode = memo(UpsampleNodeImpl)
+UpsampleNode.displayName = "UpsampleNode"

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -3,8 +3,11 @@
 import * as React from 'react'
 import { ThemeProvider as NextThemesProvider } from 'next-themes'
 
-export function ThemeProvider(
-  props: React.ComponentProps<typeof NextThemesProvider>,
-) {
-  return <NextThemesProvider {...props} />
+export function ThemeProvider({
+  children,
+  ...props
+}: React.ComponentProps<typeof NextThemesProvider> & {
+  children: React.ReactNode
+}) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>
 }

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import * as React from 'react'
+import { useTheme } from 'next-themes'
+import { Moon, Sun } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+
+export function ThemeToggle() {
+  const { resolvedTheme, setTheme } = useTheme()
+  const [mounted, setMounted] = React.useState(false)
+
+  React.useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  // Avoid hydration mismatch: render a stable placeholder until mounted.
+  if (!mounted) {
+    return (
+      <Button variant="outline" size="icon" aria-label="Toggle theme" disabled>
+        <Sun className="h-4 w-4" />
+      </Button>
+    )
+  }
+
+  const isDark = resolvedTheme === 'dark'
+
+  return (
+    <Button
+      variant="outline"
+      size="icon"
+      aria-label="Toggle theme"
+      title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+      onClick={() => setTheme(isDark ? 'light' : 'dark')}
+    >
+      {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+    </Button>
+  )
+}

--- a/lib/model-generator.ts
+++ b/lib/model-generator.ts
@@ -1,6 +1,32 @@
 
 import { type GraphIR, type GraphNode, type GraphEdge, PYTORCH_LAYER_MANIFEST } from "./types";
 
+// Options controlling the optional training-scaffold emitted after the model class.
+// When passed to `generateCode({ training })`, a runnable `if __name__ == "__main__":`
+// block is appended that instantiates the model, builds an optimizer + criterion,
+// creates a dummy dataset matching the Input node shape, and runs an epoch loop.
+export interface TrainingOptions {
+  optimizer: "adam" | "adamw" | "sgd";
+  loss: "crossentropy" | "mse" | "bce";
+  learningRate?: number;
+  epochs?: number;
+  batchSize?: number;
+}
+
+// Enum -> torch.optim class name for the training scaffold.
+const OPTIMIZER_CLASSES: Record<TrainingOptions["optimizer"], string> = {
+  adam: "Adam",
+  adamw: "AdamW",
+  sgd: "SGD",
+};
+
+// Enum -> torch.nn criterion expression for the training scaffold.
+const LOSS_CRITERIA: Record<TrainingOptions["loss"], string> = {
+  crossentropy: "nn.CrossEntropyLoss()",
+  mse: "nn.MSELoss()",
+  bce: "nn.BCEWithLogitsLoss()",
+};
+
 // Node types handled inline in the forward pass rather than as nn.Module layers
 const FUNCTIONAL_NODE_TYPES = new Set([
   "reshapeNode",
@@ -151,11 +177,13 @@ export class ModelGenerator {
     return result;
   }
 
-  generateCode(): string {
+  generateCode(options?: { training?: TrainingOptions }): string {
     const validation = this.validateGraph();
     if (!validation.valid) {
       throw new Error(validation.error);
     }
+
+    const training = options?.training;
 
     const sortedNodes = this.topologicalSort();
     const layerNodes = sortedNodes.filter(
@@ -163,6 +191,9 @@ export class ModelGenerator {
     );
 
     let code = `import torch\nimport torch.nn as nn\n`;
+    if (training) {
+      code += `from torch.utils.data import TensorDataset, DataLoader\n`;
+    }
 
     let classDefinition = `\n\nclass GeneratedModel(nn.Module):\n    def __init__(self):\n        super().__init__()\n`;
 
@@ -266,7 +297,82 @@ export class ModelGenerator {
       code += `# output = model(${inputVars.join(", ")})\n`;
       code += `# print(f"Output shape: {output.shape}")\n`;
     }
+
+    if (training) {
+      code += this.buildTrainingScaffold(training);
+    }
     return code;
+  }
+
+  // Emits a runnable training scaffold appended after the model class:
+  // an `if __name__ == "__main__":` block that instantiates GeneratedModel, moves
+  // it to the best available device, builds the optimizer + criterion, creates a
+  // dummy TensorDataset/DataLoader whose input tensor(s) match the Input node
+  // shape, and runs a forward/backward/step epoch loop with a printed loss.
+  private buildTrainingScaffold(training: TrainingOptions): string {
+    const lr = training.learningRate ?? 1e-3;
+    const epochs = training.epochs ?? 10;
+    const batchSize = training.batchSize ?? 32;
+    const numSamples = batchSize * 4;
+
+    const optimizerClass = OPTIMIZER_CLASSES[training.optimizer];
+    const criterion = LOSS_CRITERIA[training.loss];
+
+    const inputVarNames: string[] = [];
+    const inputTensorLines: string[] = [];
+    for (const inputNode of this.inputNodes) {
+      const varName = this.sanitizeArgName(inputNode.data.name || inputNode.id);
+      const d = inputNode.data as any;
+      const dims = [d.channels, d.depth, d.height, d.width, d.sequence, d.length, d.features].filter(
+        (v: any) => typeof v === "number",
+      );
+      const shape = `(num_samples${dims.map((v: number) => `, ${v}`).join("")})`;
+      inputTensorLines.push(`    ${varName} = torch.randn${shape}`);
+      inputVarNames.push(varName);
+    }
+
+    // Dummy targets sized for the selected loss. These are placeholders; replace
+    // the whole data-loading section with your real dataset.
+    const targetLines: string[] = [];
+    if (training.loss === "crossentropy") {
+      targetLines.push(`    num_classes = 10`);
+      targetLines.push(`    targets = torch.randint(0, num_classes, (num_samples,))`);
+    } else if (training.loss === "bce") {
+      targetLines.push(`    targets = torch.randint(0, 2, (num_samples, 1)).float()`);
+    } else {
+      targetLines.push(`    targets = torch.randn(num_samples, 1)`);
+    }
+
+    const datasetArgs = [...inputVarNames, "targets"].join(", ");
+
+    let scaffold = `\n\nif __name__ == "__main__":\n`;
+    scaffold += `    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")\n`;
+    scaffold += `    model = GeneratedModel().to(device)\n\n`;
+    scaffold += `    optimizer = torch.optim.${optimizerClass}(model.parameters(), lr=${lr})\n`;
+    scaffold += `    criterion = ${criterion}\n\n`;
+    scaffold += `    # Dummy data for demonstration; replace with your real dataset.\n`;
+    scaffold += `    num_samples = ${numSamples}\n`;
+    scaffold += inputTensorLines.join("\n") + `\n`;
+    scaffold += targetLines.join("\n") + `\n`;
+    scaffold += `    dataset = TensorDataset(${datasetArgs})\n`;
+    scaffold += `    dataloader = DataLoader(dataset, batch_size=${batchSize}, shuffle=True)\n\n`;
+    scaffold += `    epochs = ${epochs}\n`;
+    scaffold += `    model.train()\n`;
+    scaffold += `    for epoch in range(epochs):\n`;
+    scaffold += `        running_loss = 0.0\n`;
+    scaffold += `        for batch in dataloader:\n`;
+    scaffold += `            *inputs, targets = batch\n`;
+    scaffold += `            inputs = [t.to(device) for t in inputs]\n`;
+    scaffold += `            targets = targets.to(device)\n\n`;
+    scaffold += `            optimizer.zero_grad()\n`;
+    scaffold += `            outputs = model(*inputs)\n`;
+    scaffold += `            loss = criterion(outputs, targets)\n`;
+    scaffold += `            loss.backward()\n`;
+    scaffold += `            optimizer.step()\n\n`;
+    scaffold += `            running_loss += loss.item()\n\n`;
+    scaffold += `        avg_loss = running_loss / len(dataloader)\n`;
+    scaffold += `        print(f"Epoch {epoch + 1}/{epochs} - loss: {avg_loss:.4f}")\n`;
+    return scaffold;
   }
 
   private buildParameterString(node: GraphNode, paramNames: string[]): string {

--- a/lib/model-summary.ts
+++ b/lib/model-summary.ts
@@ -1,0 +1,173 @@
+// torchinfo / `summary()`-style text rendering for a ModelAnalysis.
+//
+// This module is purely presentational: it takes an ALREADY-COMPUTED analysis
+// object (produced by `analyzeModel(nodes, edges)` in ./model-analyzer) and
+// formats it as either a GitHub markdown table or a fixed-width plain-text
+// table. It never recomputes anything.
+
+import type { ModelAnalysis, LayerAnalysis } from "./model-analyzer"
+import type { TensorShape } from "./tensor-shape-calculator"
+
+export interface FormatModelSummaryOptions {
+  format?: "markdown" | "plain"
+}
+
+// --- Formatting helpers -----------------------------------------------------
+
+const DASH = "—"
+
+// Thousands-separated integer, e.g. 1234567 -> "1,234,567".
+function withCommas(n: number): string {
+  if (typeof n !== "number" || !isFinite(n)) return DASH
+  const rounded = Math.round(n)
+  return rounded.toLocaleString("en-US")
+}
+
+// Render a TensorShape as a torch-style tuple, e.g. "[1, 32, 8, 8]".
+// Missing dimensions render nothing; "dynamic" is preserved verbatim.
+function formatShape(shape: TensorShape | undefined | null): string {
+  if (!shape || typeof shape !== "object") return DASH
+  // Preserve a meaningful ordering of the common tensor dimensions.
+  const order: (keyof TensorShape)[] = [
+    "channels",
+    "features",
+    "sequence",
+    "depth",
+    "height",
+    "width",
+    "length",
+  ]
+  const dims: (string | number)[] = []
+  for (const key of order) {
+    const v = shape[key]
+    if (v === undefined || v === null) continue
+    dims.push(v === "dynamic" ? "dynamic" : v)
+  }
+  if (dims.length === 0) return DASH
+  return `[${dims.join(", ")}]`
+}
+
+// "type:name" label, e.g. "Conv2d (conv2dNode:conv-1)". We keep both the raw
+// layer type and the user-facing name, torchinfo-style (Layer (type)).
+function formatLayerLabel(layer: LayerAnalysis): string {
+  const type = layer.type || DASH
+  const name = layer.name || DASH
+  return `${name} (${type})`
+}
+
+function estimatedSizeMB(analysis: ModelAnalysis): number {
+  // Prefer the analyzer's own model size estimate; fall back to param bytes.
+  if (typeof analysis.modelSizeMB === "number" && isFinite(analysis.modelSizeMB)) {
+    return analysis.modelSizeMB
+  }
+  return (analysis.totalParameters * 4) / (1024 * 1024)
+}
+
+// --- Markdown -----------------------------------------------------------------
+
+function formatMarkdown(analysis: ModelAnalysis): string {
+  const header = ["Layer (type)", "Output Shape", "Param #"]
+  const lines: string[] = []
+  lines.push(`| ${header.join(" | ")} |`)
+  lines.push(`| ${header.map(() => "---").join(" | ")} |`)
+
+  for (const layer of analysis.layers ?? []) {
+    lines.push(
+      `| ${formatLayerLabel(layer)} | ${formatShape(layer.outputShape)} | ${withCommas(
+        layer.parameters,
+      )} |`,
+    )
+  }
+
+  const footer: string[] = []
+  footer.push("")
+  footer.push(`**Total params:** ${withCommas(analysis.totalParameters)}`)
+  footer.push(`**Trainable params:** ${withCommas(analysis.trainableParameters)}`)
+  footer.push(
+    `**Non-trainable params:** ${withCommas(
+      (analysis.totalParameters ?? 0) - (analysis.trainableParameters ?? 0),
+    )}`,
+  )
+  footer.push(`**Total FLOPs:** ${withCommas(analysis.totalFLOPs)}`)
+  footer.push(`**Estimated size (MB):** ${estimatedSizeMB(analysis).toFixed(2)}`)
+
+  return lines.join("\n") + "\n" + footer.join("\n") + "\n"
+}
+
+// --- Plain (fixed-width) ------------------------------------------------------
+
+function padCell(text: string, width: number): string {
+  if (text.length >= width) return text
+  return text + " ".repeat(width - text.length)
+}
+
+function formatPlain(analysis: ModelAnalysis): string {
+  const headers = ["Layer (type)", "Output Shape", "Param #"]
+  const rows: string[][] = [headers]
+
+  for (const layer of analysis.layers ?? []) {
+    rows.push([
+      formatLayerLabel(layer),
+      formatShape(layer.outputShape),
+      withCommas(layer.parameters),
+    ])
+  }
+
+  // Compute column widths from the widest cell in each column.
+  const widths = headers.map((_, col) =>
+    rows.reduce((max, row) => Math.max(max, (row[col] ?? "").length), 0),
+  )
+
+  const renderRow = (row: string[]) =>
+    row.map((cell, col) => padCell(cell ?? "", widths[col])).join("  ")
+
+  const totalWidth = widths.reduce((a, b) => a + b, 0) + (widths.length - 1) * 2
+  const divider = "=".repeat(totalWidth)
+  const thinDivider = "-".repeat(totalWidth)
+
+  const lines: string[] = []
+  lines.push(divider)
+  lines.push(renderRow(headers))
+  lines.push(divider)
+  for (let i = 1; i < rows.length; i++) {
+    lines.push(renderRow(rows[i]))
+  }
+  lines.push(divider)
+  lines.push(`Total params: ${withCommas(analysis.totalParameters)}`)
+  lines.push(`Trainable params: ${withCommas(analysis.trainableParameters)}`)
+  lines.push(
+    `Non-trainable params: ${withCommas(
+      (analysis.totalParameters ?? 0) - (analysis.trainableParameters ?? 0),
+    )}`,
+  )
+  lines.push(thinDivider)
+  lines.push(`Total FLOPs: ${withCommas(analysis.totalFLOPs)}`)
+  lines.push(`Estimated size (MB): ${estimatedSizeMB(analysis).toFixed(2)}`)
+  lines.push(divider)
+
+  return lines.join("\n") + "\n"
+}
+
+// --- Public API ---------------------------------------------------------------
+
+/**
+ * Render an already-computed ModelAnalysis as a torchinfo-style summary table.
+ * `opts.format` selects "markdown" (a GitHub markdown table, default) or
+ * "plain" (fixed-width columns). Missing/"dynamic" shapes render safely.
+ */
+export function formatModelSummary(
+  analysis: ModelAnalysis,
+  opts: FormatModelSummaryOptions = {},
+): string {
+  const format = opts.format ?? "markdown"
+  const safe: ModelAnalysis = {
+    totalParameters: analysis?.totalParameters ?? 0,
+    trainableParameters: analysis?.trainableParameters ?? 0,
+    totalFLOPs: analysis?.totalFLOPs ?? 0,
+    memoryUsageMB: analysis?.memoryUsageMB ?? 0,
+    layers: analysis?.layers ?? [],
+    modelSizeMB: analysis?.modelSizeMB ?? 0,
+    estimatedInferenceTimeMs: analysis?.estimatedInferenceTimeMs ?? 0,
+  }
+  return format === "plain" ? formatPlain(safe) : formatMarkdown(safe)
+}

--- a/lib/model-validator.ts
+++ b/lib/model-validator.ts
@@ -1,7 +1,137 @@
 import React from "react"
 import { ValidationResult } from "./types"
 import type { Node, Edge } from "@xyflow/react"
-import { validateTensorShapes, type TensorShape } from "./tensor-shape-calculator"
+import { validateTensorShapes, formatTensorShape, type TensorShape } from "./tensor-shape-calculator"
+
+// Non-batch dimensions in canonical order. Kept in sync with the calculator's
+// own ordering so "last dimension" / "which dim differs" reporting matches the
+// shapes the calculator produces.
+const CANONICAL_DIM_ORDER: (keyof TensorShape)[] = [
+  "channels",
+  "depth",
+  "height",
+  "width",
+  "sequence",
+  "length",
+  "features",
+]
+
+// Conv-family node types whose in_channels must equal the incoming tensor's
+// channel dimension. Used to produce an actionable in_channels mismatch message.
+const CONV_CHANNEL_NODE_TYPES = new Set<string>([
+  "conv1dNode",
+  "conv2dNode",
+  "conv3dNode",
+  "depthwiseconv2dNode",
+  "separableconv2dNode",
+  "convtranspose1dNode",
+  "convtranspose2dNode",
+  "convtranspose3dNode",
+])
+
+function convDisplayName(type: string | undefined): string {
+  const map: Record<string, string> = {
+    conv1dNode: "Conv1d",
+    conv2dNode: "Conv2d",
+    conv3dNode: "Conv3d",
+    depthwiseconv2dNode: "DepthwiseConv2d",
+    separableconv2dNode: "SeparableConv2d",
+    convtranspose1dNode: "ConvTranspose1d",
+    convtranspose2dNode: "ConvTranspose2d",
+    convtranspose3dNode: "ConvTranspose3d",
+  }
+  return map[type ?? ""] ?? "Conv"
+}
+
+function orderedDimNames(shape: TensorShape): (keyof TensorShape)[] {
+  return CANONICAL_DIM_ORDER.filter((d) => (shape as any)[d] !== undefined)
+}
+
+function fmtDim(v: number | "dynamic"): string {
+  return v === "dynamic" ? "?" : String(v)
+}
+
+// First dimension where two Add/Multiply inputs disagree under broadcasting
+// rules (dims must be equal, or one of them 1 / absent).
+function firstBroadcastMismatch(
+  shapes: TensorShape[],
+): { key: keyof TensorShape; a: number; b: number } | null {
+  for (const key of CANONICAL_DIM_ORDER) {
+    const vals: number[] = []
+    for (const s of shapes) {
+      const raw = (s as any)[key]
+      const dim = raw === undefined ? 1 : raw
+      if (typeof dim === "number" && dim !== 1) vals.push(dim)
+    }
+    const distinct = Array.from(new Set(vals))
+    if (distinct.length > 1) {
+      return { key, a: distinct[0], b: distinct[1] }
+    }
+  }
+  return null
+}
+
+// First problem for Concatenate: either a differing rank, or a non-concat
+// dimension whose sizes disagree. codeDim is the 0-based concat axis.
+function firstConcatMismatch(
+  shapes: TensorShape[],
+  codeDim: number,
+):
+  | { kind: "rank"; aLen: number; bLen: number }
+  | { kind: "dim"; index: number; a: number | "dynamic"; b: number | "dynamic" }
+  | null {
+  const dimNames = shapes.map(orderedDimNames)
+  const len = dimNames[0].length
+  for (let i = 1; i < dimNames.length; i++) {
+    if (dimNames[i].length !== len) {
+      return { kind: "rank", aLen: len, bLen: dimNames[i].length }
+    }
+  }
+  for (let idx = 0; idx < len; idx++) {
+    if (idx === codeDim) continue
+    let first: number | "dynamic" | undefined
+    for (let s = 0; s < shapes.length; s++) {
+      const v = (shapes[s] as any)[dimNames[s][idx]] as number | "dynamic" | undefined
+      if (v === undefined) continue
+      if (first === undefined) {
+        first = v
+      } else if (first !== v && first !== "dynamic" && v !== "dynamic") {
+        return { kind: "dim", index: idx, a: first, b: v }
+      }
+    }
+  }
+  return null
+}
+
+// Build an actionable message for Add/Multiply/Concatenate incompatibilities,
+// naming both shapes and the offending dimension. Falls back to the calculator's
+// own error text if the specific offending dim can't be localized.
+function describeOpMismatch(
+  nodeType: string,
+  nodeData: any,
+  shapes: TensorShape[],
+  fallback: string,
+): string {
+  const shapeList = shapes.map((s) => formatTensorShape(s)).join(" and ")
+
+  if (nodeType === "concatenateNode") {
+    const codeDim = Number(nodeData?.dim ?? 1) - 1
+    const detail = firstConcatMismatch(shapes, codeDim)
+    let clause = ""
+    if (detail?.kind === "rank") {
+      clause = `; one input has ${detail.aLen} dimensions and another has ${detail.bLen}`
+    } else if (detail?.kind === "dim") {
+      clause = `; dimension ${detail.index + 1} differs (${fmtDim(detail.a)} vs ${fmtDim(detail.b)})`
+    }
+    if (!detail) return fallback
+    return `Concatenate error: cannot concatenate ${shapeList} — all non-concatenated dimensions must match${clause}.`
+  }
+
+  const name = nodeType === "addNode" ? "Add" : "Multiply"
+  const detail = firstBroadcastMismatch(shapes)
+  if (!detail) return fallback
+  return `${name} error: cannot combine ${shapeList} — all dimensions must match or be broadcastable; dimension '${detail.key}' differs (${detail.a} vs ${detail.b}).`
+}
 
 export class ModelValidator {
   // Validate entire model
@@ -200,9 +330,62 @@ export class ModelValidator {
         }
       }
 
+      const label = (node.data.label as string) || node.id
+
+      // Linear: nn.Linear only transforms the LAST dimension. State expected vs
+      // actual and offer the concrete fixes (Flatten / adjust in_features /
+      // select a single position). This is the BERT/T5 class of bug.
+      if (node.type === "linearNode") {
+        const inFeatures = Number(node.data?.in_features)
+        const incoming = inputShapes.find(
+          (s): s is TensorShape => !!s && Object.keys(s).length > 0,
+        )
+        if (Number.isFinite(inFeatures) && inFeatures > 0 && incoming) {
+          const dims = orderedDimNames(incoming)
+          const last = dims.length ? (incoming as any)[dims[dims.length - 1]] : undefined
+          if (typeof last === "number" && last !== inFeatures) {
+            errors.push(
+              `Node '${label}' (linearNode): Shape mismatch — Linear expects in_features=${inFeatures} but receives a tensor whose last dimension is ${last}. Insert a Flatten node before this Linear, set in_features=${last}, or select a single token/position.`,
+            )
+          }
+        }
+        continue
+      }
+
+      // Conv family: in_channels must equal the incoming tensor's channel count.
+      if (CONV_CHANNEL_NODE_TYPES.has(node.type || "")) {
+        const inChannels = Number(node.data?.in_channels)
+        const incoming = inputShapes.find(
+          (s): s is TensorShape => !!s && Object.keys(s).length > 0,
+        )
+        const incomingChannels = incoming?.channels
+        if (
+          Number.isFinite(inChannels) &&
+          inChannels > 0 &&
+          typeof incomingChannels === "number" &&
+          incomingChannels !== inChannels
+        ) {
+          const convName = convDisplayName(node.type)
+          errors.push(
+            `Node '${label}' (${node.type}): Shape mismatch — ${convName} expects in_channels=${inChannels} but the incoming tensor has ${incomingChannels} channels. Set in_channels=${incomingChannels} to match the previous layer's output.`,
+          )
+        }
+        continue
+      }
+
       const result = validateTensorShapes(node.type || "", inputShapes, node.data)
       if (result && !result.isValid && result.error) {
-        errors.push(`Node '${node.data.label || node.id}' (${node.type}): ${result.error}`)
+        if (
+          node.type === "addNode" ||
+          node.type === "multiplyNode" ||
+          node.type === "concatenateNode"
+        ) {
+          errors.push(
+            `Node '${label}' (${node.type}): ${describeOpMismatch(node.type, node.data, connectedShapes, result.error)}`,
+          )
+        } else {
+          errors.push(`Node '${label}' (${node.type}): ${result.error}`)
+        }
       }
     }
 
@@ -217,19 +400,33 @@ export class ModelValidator {
       const nodeType = node.type
       const nodeData = node.data
 
+      const label = node.data.label || node.id
+
       switch (nodeType) {
-        case "linearNode":
-          if (!nodeData?.in_features || !nodeData?.out_features) {
-            errors.push(`Linear node ${node.data.label || node.id} is missing required parameters: in_features, out_features`)
+        case "linearNode": {
+          const missing: string[] = []
+          if (!nodeData?.in_features)
+            missing.push("in_features — set it to the size of the incoming feature dimension (e.g. 784)")
+          if (!nodeData?.out_features)
+            missing.push("out_features — set it to the desired output size (e.g. 128)")
+          if (missing.length) {
+            errors.push(`Linear node ${label} is missing ${missing.join("; and ")}.`)
           }
           break
-        case "conv2dNode":
-          if (!nodeData?.in_channels || !nodeData?.out_channels || !nodeData?.kernel_size) {
-            errors.push(
-              `Conv2D node ${node.data.label || node.id} is missing required parameters: in_channels, out_channels, kernel_size`,
-            )
+        }
+        case "conv2dNode": {
+          const missing: string[] = []
+          if (!nodeData?.in_channels)
+            missing.push("in_channels — set it to the number of input channels from the previous layer (e.g. 3)")
+          if (!nodeData?.out_channels)
+            missing.push("out_channels — set it to the number of output feature maps (e.g. 64)")
+          if (!nodeData?.kernel_size)
+            missing.push("kernel_size — set the convolution window size (e.g. 3)")
+          if (missing.length) {
+            errors.push(`Conv2d node ${label} is missing ${missing.join("; and ")}.`)
           }
           break
+        }
         case "dropoutNode":
           {
             const p = Number(nodeData?.p)

--- a/lib/share.ts
+++ b/lib/share.ts
@@ -1,0 +1,129 @@
+// Shareable-URL encoding for a model graph.
+//
+// A model graph is a React Flow `{ nodes, edges }` pair. To make a graph
+// shareable via a plain link, we serialize it to JSON and pack it into a
+// URL-safe base64url string that lives in the URL hash (`#model=...`).
+//
+// Why the hash and not a query param? The hash is never sent to the server,
+// so sharing/restoring stays entirely client-side with no server round-trip.
+//
+// KNOWN LIMITATION: base64url(JSON) grows with the graph. Very large graphs
+// can produce URLs longer than some browsers accept (~2k in older IE/Edge,
+// ~8k practical ceiling elsewhere). That is acceptable for now; a future
+// version could gzip or fall back to server-side storage for oversized graphs.
+
+export type Graph = { nodes: any[]; edges: any[] }
+
+// --- UTF-8-safe base64url helpers -----------------------------------------
+//
+// `btoa`/`atob` operate on "binary strings" (one byte per char) and throw on
+// characters outside the Latin-1 range. Graphs may contain non-ASCII text
+// (unicode node labels, etc.), so we bridge through a UTF-8 byte encoding.
+// `TextEncoder`/`TextDecoder` exist in modern browsers and in jsdom/Node, so
+// they work in both the app and the vitest test environment.
+
+function bytesToBinaryString(bytes: Uint8Array): string {
+  let binary = ""
+  // Chunk to avoid "Maximum call stack size exceeded" on large inputs when
+  // spreading into String.fromCharCode.
+  const chunkSize = 0x8000
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    const chunk = bytes.subarray(i, i + chunkSize)
+    binary += String.fromCharCode.apply(null, chunk as unknown as number[])
+  }
+  return binary
+}
+
+function binaryStringToBytes(binary: string): Uint8Array {
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return bytes
+}
+
+function base64Encode(binary: string): string {
+  if (typeof btoa === "function") return btoa(binary)
+  // Node fallback (should not be needed under jsdom, which provides btoa).
+  return Buffer.from(binary, "binary").toString("base64")
+}
+
+function base64Decode(b64: string): string {
+  if (typeof atob === "function") return atob(b64)
+  return Buffer.from(b64, "base64").toString("binary")
+}
+
+function toBase64Url(b64: string): string {
+  return b64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "")
+}
+
+function fromBase64Url(b64url: string): string {
+  let b64 = b64url.replace(/-/g, "+").replace(/_/g, "/")
+  // Restore stripped padding so atob/Buffer can decode.
+  const pad = b64.length % 4
+  if (pad === 2) b64 += "=="
+  else if (pad === 3) b64 += "="
+  else if (pad === 1) throw new Error("Invalid base64url length")
+  return b64
+}
+
+// --- Public API -------------------------------------------------------------
+
+/**
+ * Serialize a graph to a URL-safe base64url string (UTF-8 safe).
+ */
+export function encodeGraph(graph: Graph): string {
+  const json = JSON.stringify({ nodes: graph.nodes ?? [], edges: graph.edges ?? [] })
+  const bytes = new TextEncoder().encode(json)
+  const binary = bytesToBinaryString(bytes)
+  return toBase64Url(base64Encode(binary))
+}
+
+/**
+ * Inverse of `encodeGraph`. Returns null (never throws) on malformed input.
+ */
+export function decodeGraph(encoded: string): Graph | null {
+  if (typeof encoded !== "string" || encoded.length === 0) return null
+  try {
+    const binary = base64Decode(fromBase64Url(encoded))
+    const bytes = binaryStringToBytes(binary)
+    const json = new TextDecoder().decode(bytes)
+    const parsed = JSON.parse(json)
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      !Array.isArray(parsed.nodes) ||
+      !Array.isArray(parsed.edges)
+    ) {
+      return null
+    }
+    return { nodes: parsed.nodes, edges: parsed.edges }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Build a shareable link: `${baseUrl}#model=<encoded>`. The graph rides in the
+ * hash so it is never sent to the server.
+ */
+export function buildShareUrl(baseUrl: string, graph: Graph): string {
+  return `${baseUrl}#model=${encodeGraph(graph)}`
+}
+
+/**
+ * Parse a `#model=...` hash (with or without the leading `#`) and return the
+ * decoded graph, or null if the hash is empty, missing `model=`, or malformed.
+ */
+export function readGraphFromHash(hash: string): Graph | null {
+  if (typeof hash !== "string" || hash.length === 0) return null
+  const raw = hash.startsWith("#") ? hash.slice(1) : hash
+  if (raw.length === 0) return null
+  // The hash may carry other params (`a=b&model=...`); scan each segment.
+  for (const part of raw.split("&")) {
+    if (part.startsWith("model=")) {
+      return decodeGraph(part.slice("model=".length))
+    }
+  }
+  return null
+}

--- a/tests/model-generator.test.ts
+++ b/tests/model-generator.test.ts
@@ -452,6 +452,106 @@ describe('ModelGenerator', () => {
         expect(() => generator.generateCode()).toThrow(/input node/i);
     });
 
+    it('emits no training scaffold by default (byte-for-byte model-only output)', () => {
+        const graph = () => makeGraph(
+            [
+                inputNode('input1', { name: 'x', features: 784 }),
+                { id: 'fc1', type: 'linearNode', data: { in_features: 784, out_features: 128 } },
+            ],
+            [{ id: 'e1', source: 'input1', target: 'fc1' }],
+        );
+
+        const code = graph().generateCode();
+        expect(code).not.toContain('__main__');
+        expect(code).not.toContain('torch.optim');
+        expect(code).not.toContain('DataLoader');
+        expect(code).not.toContain('from torch.utils.data');
+
+        // Passing an options object without `training` is identical to no options.
+        expect(graph().generateCode({})).toBe(code);
+    });
+
+    it('appends a training scaffold with optimizer, criterion, DataLoader and epoch loop', () => {
+        const code = makeGraph(
+            [
+                inputNode('input1', { name: 'x', features: 784 }),
+                { id: 'fc1', type: 'linearNode', data: { in_features: 784, out_features: 10 } },
+            ],
+            [{ id: 'e1', source: 'input1', target: 'fc1' }],
+        ).generateCode({ training: { optimizer: 'adam', loss: 'crossentropy' } });
+
+        // Imports for training only appear when training is emitted.
+        expect(code).toContain('from torch.utils.data import TensorDataset, DataLoader');
+        // Scaffold structure
+        expect(code).toContain('if __name__ == "__main__":');
+        expect(code).toContain('device = torch.device("cuda" if torch.cuda.is_available() else "cpu")');
+        expect(code).toContain('model = GeneratedModel().to(device)');
+        expect(code).toContain('torch.optim.Adam(model.parameters(), lr=0.001)');
+        expect(code).toContain('criterion = nn.CrossEntropyLoss()');
+        expect(code).toContain('dataset = TensorDataset(x, targets)');
+        expect(code).toContain('dataloader = DataLoader(dataset, batch_size=32, shuffle=True)');
+        expect(code).toContain('for epoch in range(epochs):');
+        expect(code).toContain('optimizer.zero_grad()');
+        expect(code).toContain('loss.backward()');
+        expect(code).toContain('optimizer.step()');
+        // Scaffold comes after the model class.
+        expect(code.indexOf('class GeneratedModel')).toBeLessThan(code.indexOf('__main__'));
+    });
+
+    it('maps each optimizer enum to the right torch.optim class', () => {
+        const build = (optimizer: 'adam' | 'adamw' | 'sgd') => makeGraph(
+            [
+                inputNode('input1', { name: 'x', features: 8 }),
+                { id: 'fc1', type: 'linearNode', data: { in_features: 8, out_features: 2 } },
+            ],
+            [{ id: 'e1', source: 'input1', target: 'fc1' }],
+        ).generateCode({ training: { optimizer, loss: 'mse' } });
+
+        expect(build('adam')).toContain('torch.optim.Adam(model.parameters()');
+        expect(build('adamw')).toContain('torch.optim.AdamW(model.parameters()');
+        expect(build('sgd')).toContain('torch.optim.SGD(model.parameters()');
+    });
+
+    it('maps each loss enum to the right criterion', () => {
+        const build = (loss: 'crossentropy' | 'mse' | 'bce') => makeGraph(
+            [
+                inputNode('input1', { name: 'x', features: 8 }),
+                { id: 'fc1', type: 'linearNode', data: { in_features: 8, out_features: 2 } },
+            ],
+            [{ id: 'e1', source: 'input1', target: 'fc1' }],
+        ).generateCode({ training: { optimizer: 'adam', loss } });
+
+        expect(build('crossentropy')).toContain('criterion = nn.CrossEntropyLoss()');
+        expect(build('mse')).toContain('criterion = nn.MSELoss()');
+        expect(build('bce')).toContain('criterion = nn.BCEWithLogitsLoss()');
+    });
+
+    it('honours learningRate, epochs and batchSize overrides', () => {
+        const code = makeGraph(
+            [
+                inputNode('input1', { name: 'x', features: 8 }),
+                { id: 'fc1', type: 'linearNode', data: { in_features: 8, out_features: 2 } },
+            ],
+            [{ id: 'e1', source: 'input1', target: 'fc1' }],
+        ).generateCode({ training: { optimizer: 'sgd', loss: 'mse', learningRate: 0.05, epochs: 3, batchSize: 16 } });
+
+        expect(code).toContain('lr=0.05');
+        expect(code).toContain('epochs = 3');
+        expect(code).toContain('batch_size=16');
+    });
+
+    it('sizes the dummy input tensor from the Input node shape', () => {
+        const code = makeGraph(
+            [
+                inputNode('input1', { name: 'x', channels: 3, height: 28, width: 28 }),
+                { id: 'conv1', type: 'conv2dNode', data: { in_channels: 3, out_channels: 16, kernel_size: 3 } },
+            ],
+            [{ id: 'e1', source: 'input1', target: 'conv1' }],
+        ).generateCode({ training: { optimizer: 'adam', loss: 'crossentropy' } });
+
+        expect(code).toContain('x = torch.randn(num_samples, 3, 28, 28)');
+    });
+
     it('rejects cyclic graphs', () => {
         const generator = makeGraph(
             [

--- a/tests/model-summary.test.ts
+++ b/tests/model-summary.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from "vitest"
+import { formatModelSummary } from "../lib/model-summary"
+import type { ModelAnalysis } from "../lib/model-analyzer"
+
+const fakeAnalysis: ModelAnalysis = {
+  totalParameters: 203530,
+  trainableParameters: 203402,
+  totalFLOPs: 407060,
+  memoryUsageMB: 1.5,
+  modelSizeMB: 0.78,
+  estimatedInferenceTimeMs: 0.4,
+  layers: [
+    {
+      name: "fc1",
+      type: "linearNode",
+      parameters: 200960,
+      trainableParameters: 200960,
+      flops: 401920,
+      memoryMB: 0.8,
+      inputShape: { features: 784 },
+      outputShape: { features: 256 },
+    },
+    {
+      name: "bn1",
+      type: "batchnorm1dNode",
+      parameters: 1024,
+      trainableParameters: 512,
+      flops: 512,
+      memoryMB: 0.1,
+      inputShape: { features: 256 },
+      outputShape: { features: 256 },
+    },
+    {
+      name: "head",
+      type: "linearNode",
+      parameters: 1546,
+      trainableParameters: 1546,
+      flops: 3092,
+      memoryMB: 0.01,
+      inputShape: { features: 256 },
+      // Missing/dynamic output shape should render safely.
+      outputShape: { features: "dynamic" },
+    },
+  ],
+}
+
+describe("formatModelSummary - markdown", () => {
+  const out = formatModelSummary(fakeAnalysis, { format: "markdown" })
+
+  it("renders a markdown table header", () => {
+    expect(out).toContain("| Layer (type) | Output Shape | Param # |")
+    expect(out).toContain("| --- | --- | --- |")
+  })
+
+  it("includes each layer row with type:name label", () => {
+    expect(out).toContain("fc1 (linearNode)")
+    expect(out).toContain("bn1 (batchnorm1dNode)")
+    expect(out).toContain("head (linearNode)")
+  })
+
+  it("formats param counts with thousands separators", () => {
+    expect(out).toContain("200,960")
+  })
+
+  it("renders shapes and dynamic dims", () => {
+    expect(out).toContain("[256]")
+    expect(out).toContain("[dynamic]")
+  })
+
+  it("includes the totals footer", () => {
+    expect(out).toContain("**Total params:** 203,530")
+    expect(out).toContain("**Trainable params:** 203,402")
+    expect(out).toContain("**Non-trainable params:** 128")
+    expect(out).toContain("**Total FLOPs:** 407,060")
+    expect(out).toContain("**Estimated size (MB):** 0.78")
+  })
+})
+
+describe("formatModelSummary - plain", () => {
+  const out = formatModelSummary(fakeAnalysis, { format: "plain" })
+
+  it("includes column headers and layer rows", () => {
+    expect(out).toContain("Layer (type)")
+    expect(out).toContain("Output Shape")
+    expect(out).toContain("Param #")
+    expect(out).toContain("fc1 (linearNode)")
+    expect(out).toContain("bn1 (batchnorm1dNode)")
+    expect(out).toContain("head (linearNode)")
+  })
+
+  it("includes the totals footer", () => {
+    expect(out).toContain("Total params: 203,530")
+    expect(out).toContain("Trainable params: 203,402")
+    expect(out).toContain("Non-trainable params: 128")
+    expect(out).toContain("Total FLOPs: 407,060")
+    expect(out).toContain("Estimated size (MB): 0.78")
+  })
+
+  it("uses fixed-width alignment (no markdown pipes for data rows)", () => {
+    // Plain format should not contain markdown table pipes.
+    expect(out).not.toContain("| Layer (type) |")
+  })
+})
+
+describe("formatModelSummary - defaults and robustness", () => {
+  it("defaults to markdown when no format is given", () => {
+    const out = formatModelSummary(fakeAnalysis)
+    expect(out).toContain("| Layer (type) | Output Shape | Param # |")
+  })
+
+  it("does not crash on an empty analysis", () => {
+    const empty: ModelAnalysis = {
+      totalParameters: 0,
+      trainableParameters: 0,
+      totalFLOPs: 0,
+      memoryUsageMB: 0,
+      modelSizeMB: 0,
+      estimatedInferenceTimeMs: 0,
+      layers: [],
+    }
+    const md = formatModelSummary(empty, { format: "markdown" })
+    const plain = formatModelSummary(empty, { format: "plain" })
+    expect(md).toContain("**Total params:** 0")
+    expect(plain).toContain("Total params: 0")
+  })
+
+  it("renders — for a missing output shape", () => {
+    const analysis: ModelAnalysis = {
+      totalParameters: 10,
+      trainableParameters: 10,
+      totalFLOPs: 0,
+      memoryUsageMB: 0,
+      modelSizeMB: 0,
+      estimatedInferenceTimeMs: 0,
+      layers: [
+        {
+          name: "x",
+          type: "reluNode",
+          parameters: 0,
+          flops: 0,
+          memoryMB: 0,
+          inputShape: {} as any,
+          outputShape: undefined as any,
+        },
+      ],
+    }
+    const out = formatModelSummary(analysis, { format: "plain" })
+    expect(out).toContain("—")
+  })
+})

--- a/tests/model-validator.test.ts
+++ b/tests/model-validator.test.ts
@@ -130,4 +130,131 @@ describe('ModelValidator', () => {
             expect(result.errors.some(err => err.includes('mismatch'))).toBe(true);
         });
     });
+
+    describe('actionable shape-mismatch messages', () => {
+        it('Linear in_features mismatch states expected vs actual and suggests a fix (BERT/T5 class)', () => {
+            const nodes = [
+                {
+                    id: 'input-1',
+                    type: 'inputNode',
+                    position: { x: 0, y: 0 },
+                    data: { features: 393216, outputShape: { features: 393216 } },
+                },
+                {
+                    id: 'linear-1',
+                    type: 'linearNode',
+                    position: { x: 200, y: 0 },
+                    data: { in_features: 768, out_features: 768 },
+                },
+            ];
+            const edges = [{ id: 'e1', source: 'input-1', target: 'linear-1' }];
+
+            const result = validator.validateModel(nodes, edges);
+            expect(result.isValid).toBe(false);
+            const msg = result.errors.find(e => e.includes('in_features')) ?? '';
+            // expected vs actual numbers
+            expect(msg).toMatch(/in_features=768/);
+            expect(msg).toMatch(/last dimension is 393216/);
+            // concrete fix suggestions
+            expect(msg).toMatch(/Flatten/);
+            expect(msg).toMatch(/in_features=393216/);
+            expect(msg).toMatch(/single token\/position/);
+        });
+
+        it('Conv2d in_channels mismatch names both channel counts and the fix', () => {
+            const nodes = [
+                {
+                    id: 'input-1',
+                    type: 'inputNode',
+                    position: { x: 0, y: 0 },
+                    data: { channels: 32, height: 8, width: 8, outputShape: { channels: 32, height: 8, width: 8 } },
+                },
+                {
+                    id: 'conv-1',
+                    type: 'conv2dNode',
+                    position: { x: 200, y: 0 },
+                    data: { in_channels: 64, out_channels: 64, kernel_size: 3 },
+                },
+            ];
+            const edges = [{ id: 'e1', source: 'input-1', target: 'conv-1' }];
+
+            const result = validator.validateModel(nodes, edges);
+            expect(result.isValid).toBe(false);
+            const msg = result.errors.find(e => e.includes('in_channels')) ?? '';
+            expect(msg).toMatch(/Conv2d expects in_channels=64/);
+            expect(msg).toMatch(/incoming tensor has 32 channels/);
+            expect(msg).toMatch(/Set in_channels=32/);
+        });
+
+        it('Add with incompatible inputs names both shapes and the offending dim', () => {
+            const nodes = [
+                { id: 'a', type: 'inputNode', position: { x: 0, y: 0 }, data: { features: 128, outputShape: { features: 128 } } },
+                { id: 'b', type: 'inputNode', position: { x: 0, y: 100 }, data: { features: 256, outputShape: { features: 256 } } },
+                { id: 'add', type: 'addNode', position: { x: 200, y: 50 }, data: { num_inputs: 2 } },
+            ];
+            const edges = [
+                { id: 'e1', source: 'a', target: 'add', targetHandle: 'input1' },
+                { id: 'e2', source: 'b', target: 'add', targetHandle: 'input2' },
+            ];
+
+            const result = validator.validateModel(nodes, edges);
+            expect(result.isValid).toBe(false);
+            const msg = result.errors.find(e => e.includes('Add error')) ?? '';
+            expect(msg).toMatch(/\[128\]/);
+            expect(msg).toMatch(/\[256\]/);
+            expect(msg).toMatch(/dimension 'features' differs \(128 vs 256\)/);
+            expect(msg).toMatch(/broadcastable/);
+        });
+
+        it('Concatenate with mismatched non-concat dim names both shapes and the dim', () => {
+            const nodes = [
+                { id: 'a', type: 'inputNode', position: { x: 0, y: 0 }, data: { sequence: 10, features: 128, outputShape: { sequence: 10, features: 128 } } },
+                { id: 'b', type: 'inputNode', position: { x: 0, y: 100 }, data: { sequence: 20, features: 128, outputShape: { sequence: 20, features: 128 } } },
+                { id: 'cat', type: 'concatenateNode', position: { x: 200, y: 50 }, data: { num_inputs: 2, dim: 2 } },
+            ];
+            const edges = [
+                { id: 'e1', source: 'a', target: 'cat', targetHandle: 'input1' },
+                { id: 'e2', source: 'b', target: 'cat', targetHandle: 'input2' },
+            ];
+
+            const result = validator.validateModel(nodes, edges);
+            expect(result.isValid).toBe(false);
+            const msg = result.errors.find(e => e.includes('Concatenate error')) ?? '';
+            expect(msg).toMatch(/\[10, 128\]/);
+            expect(msg).toMatch(/\[20, 128\]/);
+            expect(msg).toMatch(/non-concatenated dimensions must match/);
+            expect(msg).toMatch(/dimension 1 differs \(10 vs 20\)/);
+        });
+    });
+
+    describe('missing required parameters', () => {
+        it('names the missing param, its layer, and a sensible default', () => {
+            const nodes = [
+                {
+                    id: 'conv-1',
+                    type: 'conv2dNode',
+                    position: { x: 0, y: 0 },
+                    data: { in_channels: 3, kernel_size: 3 }, // out_channels missing
+                },
+            ];
+
+            const result = validator.validateModel(nodes, []);
+            expect(result.isValid).toBe(false);
+            const msg = result.errors.find(e => e.includes('out_channels')) ?? '';
+            expect(msg).toMatch(/Conv2d node/);
+            expect(msg).toMatch(/out_channels/);
+            expect(msg).toMatch(/number of output feature maps/);
+            expect(msg).toMatch(/e\.g\. 64/);
+        });
+
+        it('Linear reports each missing param with a default suggestion', () => {
+            const nodes = [
+                { id: 'lin-1', type: 'linearNode', position: { x: 0, y: 0 }, data: {} },
+            ];
+            const result = validator.validateModel(nodes, []);
+            const msg = result.errors.find(e => e.includes('Linear node')) ?? '';
+            expect(msg).toMatch(/in_features/);
+            expect(msg).toMatch(/out_features/);
+        });
+    });
 });

--- a/tests/share.test.ts
+++ b/tests/share.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest"
+import {
+  encodeGraph,
+  decodeGraph,
+  buildShareUrl,
+  readGraphFromHash,
+  type Graph,
+} from "../lib/share"
+
+const sampleGraph: Graph = {
+  nodes: [
+    {
+      id: "input-1",
+      type: "inputNode",
+      position: { x: 100, y: 200 },
+      data: { channels: 1, height: 28, width: 28 },
+    },
+    {
+      id: "linear-1",
+      type: "linearNode",
+      position: { x: 500, y: 200 },
+      data: { in_features: 784, out_features: 256, name: "fc1" },
+    },
+  ],
+  edges: [{ id: "e1", source: "input-1", target: "linear-1" }],
+}
+
+describe("encodeGraph / decodeGraph", () => {
+  it("round-trips a graph exactly", () => {
+    const encoded = encodeGraph(sampleGraph)
+    expect(typeof encoded).toBe("string")
+    const decoded = decodeGraph(encoded)
+    expect(decoded).toEqual(sampleGraph)
+  })
+
+  it("produces a URL-safe base64url string (no +, /, or =)", () => {
+    // Build a graph large enough to force base64 padding/special chars.
+    const big: Graph = {
+      nodes: Array.from({ length: 50 }, (_, i) => ({
+        id: `n${i}`,
+        type: "linearNode",
+        data: { in_features: i, out_features: i + 1, name: `layer ${i} >>> /\\?` },
+      })),
+      edges: [],
+    }
+    const encoded = encodeGraph(big)
+    expect(encoded).not.toMatch(/[+/=]/)
+    expect(decodeGraph(encoded)).toEqual(big)
+  })
+
+  it("round-trips a graph with unicode in a node label", () => {
+    const unicodeGraph: Graph = {
+      nodes: [
+        {
+          id: "u1",
+          type: "linearNode",
+          data: { name: "层 café 😀 Ω → ✓ Ελληνικά", note: "日本語テスト" },
+        },
+      ],
+      edges: [],
+    }
+    const encoded = encodeGraph(unicodeGraph)
+    const decoded = decodeGraph(encoded)
+    expect(decoded).toEqual(unicodeGraph)
+    expect(decoded?.nodes[0].data.name).toBe("层 café 😀 Ω → ✓ Ελληνικά")
+  })
+
+  it("round-trips an empty graph", () => {
+    const empty: Graph = { nodes: [], edges: [] }
+    const decoded = decodeGraph(encodeGraph(empty))
+    expect(decoded).toEqual(empty)
+  })
+
+  it("returns null for empty string", () => {
+    expect(decodeGraph("")).toBeNull()
+  })
+
+  it("returns null for malformed input instead of throwing", () => {
+    expect(decodeGraph("!!!not base64!!!")).toBeNull()
+    expect(decodeGraph("####")).toBeNull()
+    // Valid base64url but not JSON.
+    expect(decodeGraph(encodeGraph({ nodes: [], edges: [] }) + "garbage")).toBeNull()
+  })
+
+  it("returns null when decoded JSON is not a graph shape", () => {
+    // Encode a plain array (valid JSON, wrong shape).
+    const notAGraph = encodeGraph({ nodes: undefined as any, edges: undefined as any })
+    // encodeGraph defaults undefined to [], so this actually is valid; test a
+    // hand-rolled encoding of a non-graph object instead.
+    const encodedNumber = (() => {
+      const json = JSON.stringify(42)
+      const bytes = new TextEncoder().encode(json)
+      let binary = ""
+      bytes.forEach((b) => (binary += String.fromCharCode(b)))
+      return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "")
+    })()
+    expect(decodeGraph(encodedNumber)).toBeNull()
+    expect(decodeGraph(notAGraph)).toEqual({ nodes: [], edges: [] })
+  })
+})
+
+describe("buildShareUrl / readGraphFromHash", () => {
+  it("builds a #model= url and reads it back", () => {
+    const url = buildShareUrl("https://example.com/designer", sampleGraph)
+    expect(url.startsWith("https://example.com/designer#model=")).toBe(true)
+    const hash = url.slice(url.indexOf("#"))
+    expect(readGraphFromHash(hash)).toEqual(sampleGraph)
+  })
+
+  it("accepts a hash with or without the leading #", () => {
+    const encoded = encodeGraph(sampleGraph)
+    expect(readGraphFromHash(`#model=${encoded}`)).toEqual(sampleGraph)
+    expect(readGraphFromHash(`model=${encoded}`)).toEqual(sampleGraph)
+  })
+
+  it("finds model= among other hash params", () => {
+    const encoded = encodeGraph(sampleGraph)
+    expect(readGraphFromHash(`#tab=code&model=${encoded}&x=1`)).toEqual(sampleGraph)
+  })
+
+  it("returns null for empty hash", () => {
+    expect(readGraphFromHash("")).toBeNull()
+    expect(readGraphFromHash("#")).toBeNull()
+  })
+
+  it("returns null for a hash without model=", () => {
+    expect(readGraphFromHash("#tab=code&foo=bar")).toBeNull()
+  })
+
+  it("returns null when model payload is malformed", () => {
+    expect(readGraphFromHash("#model=!!!bad!!!")).toBeNull()
+  })
+})


### PR DESCRIPTION
Follow-up to the merged #12, continuing the staged improvement program. Contains **Wave 4** (safe UX/perf) and **Wave 5** (features). All verified: 0 TS errors, 228 tests, lint clean, `next build` OK, plus real-browser (Playwright) checks.

## Wave 4 — UX & performance
- **Dark mode now works.** `next-themes`/`theme-provider.tsx` existed but were **never mounted**. Mounted `ThemeProvider` in `app/layout.tsx` + added a Sun/Moon **theme toggle**; migrated hardcoded light-only colors in chrome/dialogs to semantic tokens (node accent colors left intact).
- **ErrorBoundary** (previously unused) now wraps the ReactFlow canvas.
- **Memoized all 70 node components** with `React.memo` (none were before) — editing/dragging one node no longer re-renders the whole canvas.

## Wave 5 — features
- **Training-loop code generation.** `generateCode({ training })` optionally appends a runnable `if __name__ == "__main__"` scaffold — device, optimizer (Adam/AdamW/SGD), loss (CrossEntropy/MSE/BCE), a dummy `DataLoader` shaped from the Input node, and a train loop. Backward compatible. Exposed via an "Include training loop" toggle in the Code dialog.
- **Actionable shape diagnostics.** Validation messages now state expected vs actual and a concrete fix — e.g. *"Linear expects in_features=768 but receives … 393216. Insert a Flatten, set in_features=393216, or select a single token."* (the exact BERT/T5 failure class), plus a new Conv `in_channels` check.
- **Shareable URLs.** Graph encoded into a Unicode-safe base64url URL hash; a header **Share** button copies the link, and a `#model=…` hash restores the graph on load. Fully client-side. *(Browser-verified round-trip.)*
- **Model summary export.** torchinfo-style per-layer table (markdown/plain) from the existing analysis, with a **Copy summary** button in the Model Analysis dialog.

## Verification
0 TypeScript errors · 228 tests (+36 new across share, model-summary, model-generator, model-validator) · lint clean · `next build` OK · Playwright: dark-mode toggle, share URL round-trip (loads a graph from its link), and the new controls all confirmed working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Dkh8yTA6d21grrL9StTKA